### PR TITLE
Add GitHub workflow to build and publish the app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,8 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-
+    tags:
+      - v*
 jobs:
   publish:
     name: Publish (${{ matrix.os }} - ${{ matrix.arch }})


### PR DESCRIPTION
To build and publish the app for releases

Based on the [Electron Fiddle build workflow](https://github.com/electron/fiddle/blob/1d2b2865f4276cdee90d5c020aab5087f74bbe02/.github/workflows/build.yml).