### PR TITLE
bring back full application menu

### DIFF
--- a/src/createMenu.ts
+++ b/src/createMenu.ts
@@ -1,20 +1,110 @@
-import { Menu, MenuItem } from "electron";
+import { app, Menu, MenuItem, MenuItemConstructorOptions } from "electron";
 import createWindow from "./createWindow";
+import { isMac } from "./platform";
 
-export default function createMenu(): Menu {
+export function createDockMenu(): Menu {
   const menu = new Menu();
+
   menu.append(
     new MenuItem({
-      label: "Replit",
-      submenu: [
-        {
-          label: "Create new window",
-          accelerator: "CommandOrControl+Shift+N",
-          click: () => createWindow(),
-        },
-      ],
+      label: "New Window",
+      accelerator: "CommandOrControl+Shift+N",
+      click: () => createWindow(),
     })
   );
+
+  return menu;
+}
+
+export function createApplicationMenu(): Menu {
+  const template = [];
+
+  // App Menu
+  if (isMac()) {
+    template.push({
+      label: app.name,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        { role: "services" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    });
+  }
+
+  // File Menu
+  template.push({
+    label: "File",
+    submenu: [
+      {
+        label: "New Window",
+        accelerator: "CommandOrControl+Shift+N",
+        click: () => createWindow(),
+      },
+      isMac() ? { role: "close" } : { role: "quit" },
+    ],
+  });
+
+  // Edit Menu
+  template.push({
+    label: "Edit",
+    submenu: [
+      { role: "undo" },
+      { role: "redo" },
+      { type: "separator" },
+      { role: "cut" },
+      { role: "copy" },
+      { role: "paste" },
+      { role: "pasteandmatchstyle" },
+      { role: "delete" },
+      { role: "selectall" },
+    ],
+  });
+
+  // View Menu
+  template.push({
+    label: "View",
+    submenu: [
+      { role: "reload" },
+      { role: "forceReload" },
+      { role: "toggleDevTools" },
+      { type: "separator" },
+      { role: "resetZoom" },
+      { role: "zoomIn" },
+      { role: "zoomOut" },
+      { type: "separator" },
+      { role: "togglefullscreen" },
+    ],
+  });
+
+  // Window Menu
+  template.push({
+    label: "Window",
+    submenu: [
+      { role: "minimize" },
+      { role: "zoom" },
+      ...(isMac()
+        ? [
+            { type: "separator" },
+            { role: "front" },
+            { type: "separator" },
+            { role: "window" },
+          ]
+        : [{ role: "close" }]),
+    ],
+  });
+
+  // Help Menu
+  template.push({
+    role: "help",
+  });
+
+  const menu = Menu.buildFromTemplate(template as MenuItemConstructorOptions[]);
 
   return menu;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 import { app, Menu, BrowserWindow } from "electron";
 import createWindow from "./createWindow";
-import createMenu from "./createMenu";
 import { appIcon } from "./constants";
 import { isMac } from "./platform";
+import { createApplicationMenu, createDockMenu } from "./createMenu";
 
 // This should run as early in the main process as possible
 if (require("electron-squirrel-startup")) app.quit();
@@ -23,9 +23,10 @@ if (!instanceLock) {
   app.quit();
 }
 
-const menu = createMenu();
+const applicationMenu = createApplicationMenu();
+const dockMenu = createDockMenu();
 
-Menu.setApplicationMenu(menu);
+Menu.setApplicationMenu(applicationMenu);
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
@@ -34,7 +35,7 @@ app.whenReady().then(() => {
   // MacOS only APIs
   if (isMac()) {
     app.dock.setIcon(appIcon);
-    app.dock.setMenu(menu);
+    app.dock.setMenu(dockMenu);
   }
 
   createWindow();


### PR DESCRIPTION
The "New Window" addition to the menu removed all the default menu items. This PR brings them back.

There's way more to figure out here, like adding shortcuts from the web view to the menubar or hiding the developer tools for production builds, but for now this is a step in the right direction.