### PR TITLE
Implement autoupdates

### DIFF
--- a/src/checkForUpdates.ts
+++ b/src/checkForUpdates.ts
@@ -1,0 +1,44 @@
+import { app, autoUpdater, dialog } from "electron";
+import { isLinux, isWindows } from "./platform";
+
+const server = "https://desktop-app-releases.replit.app";
+const url = `${server}/update/${process.platform}/${app.getVersion()}`;
+
+export default function checkForUpdates(): void {
+  // The app must be packaged in order to check for updates.
+  if (!app.isPackaged) {
+    return;
+  }
+
+  // The autoUpdater module does not support Linux
+  if (isLinux()) {
+    return;
+  }
+
+  autoUpdater.setFeedURL({ url });
+
+  autoUpdater.on("update-downloaded", (_event, releaseNotes, releaseName) => {
+    const dialogOpts = {
+      type: "info",
+      buttons: ["Restart", "Later"],
+      title: "Application Update",
+      // On Windows only releaseName is available.
+      message: isWindows() ? releaseName : releaseNotes,
+      detail:
+        "A new version has been downloaded. Restart the application to apply the updates.",
+    };
+
+    dialog.showMessageBox(dialogOpts).then((returnValue) => {
+      if (returnValue.response === 0) {
+        autoUpdater.quitAndInstall();
+      }
+    });
+  });
+
+  autoUpdater.on("error", (message) => {
+    console.error("There was a problem updating the application");
+    console.error(message);
+  });
+
+  autoUpdater.checkForUpdates();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import createWindow from "./createWindow";
 import { macAppIcon } from "./constants";
 import { isMac } from "./platform";
 import { createApplicationMenu, createDockMenu } from "./createMenu";
+import checkForUpdates from "./checkForUpdates";
 
 // This should run as early in the main process as possible
 if (require("electron-squirrel-startup")) app.quit();
@@ -39,6 +40,7 @@ app.whenReady().then(() => {
   }
 
   createWindow();
+  checkForUpdates();
 
   app.on("activate", function () {
     // On macOS it's common to re-create a window in the app when the


### PR DESCRIPTION
Pretty self-explanatory: we want users who download the desktop app to be able to install and use the latest version as it's released without having to manually re-download.

This PR implements autoupdates according to [this tutorial](https://www.electronjs.org/docs/latest/tutorial/updates). The desktop release server lives in a Repl here: https://replit.com/@util/desktop-releases that is deployed. See relevant [Asana task](https://app.asana.com/0/1204365477281677/1204367612102167/f).

Note that right now we only check for updates once when the app starts up. I think this is fine given that updates will be infrequent. My hesitation in polling every N minutes is that I don't want to overload the release server.