### PR TITLE
Open external links from child windows in default browser

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -65,6 +65,24 @@ export default function createWindow(props?: WindowProps): void {
     ...platformStyling,
   });
 
+  window.webContents.setWindowOpenHandler((details) => {
+    const url = new URL(details.url);
+    const isReplit = url.origin === "https://replit.com";
+    const isReplCo = url.host.endsWith("repl.co");
+
+    if (!isReplit && !isReplCo) {
+      shell.openExternal(details.url);
+
+      return {
+        action: "deny",
+      };
+    }
+
+    return {
+      action: "allow",
+    };
+  });
+
   window.setBounds(getWindowBounds());
 
   // Add a custom string to user agent to make it easier to differentiate requests from desktop app


### PR DESCRIPTION
Scott pointed out that opening (private) GH links doesn't work in the desktop app since it opens in an Electron window that is not authed. I thought we already redirected all external links to the browser but we didn't handle the case where it opens inside a child window which will happen if you click a link with `target="_blank"` see [docs](https://www.electronjs.org/docs/latest/api/window-open)