### PR TITLE
don't show developer tools when running packaged app

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { nativeImage } from "electron";
+import { app, nativeImage } from "electron";
 import * as path from "path";
 
 /**
@@ -32,3 +32,6 @@ export const preloadScript = path.join(__dirname, "preload.js");
 export const baseUrl = process.env.USE_LOCAL_URL
   ? `http://localhost:3000`
   : `https://replit.com`;
+
+// https://www.electronjs.org/docs/latest/api/app#appispackaged-readonly
+export const isProduction = app.isPackaged;

--- a/src/createMenu.ts
+++ b/src/createMenu.ts
@@ -6,6 +6,7 @@ import {
   MenuItem,
   MenuItemConstructorOptions,
 } from "electron";
+import { isProduction } from "./constants";
 import { createFullWindow, createSplashScreenWindow } from "./createWindow";
 import { isMac } from "./platform";
 
@@ -91,14 +92,20 @@ export function createApplicationMenu(): Menu {
     ],
   });
 
+  const devSubmenu = isProduction
+    ? []
+    : [
+        { role: "reload" },
+        { role: "forceReload" },
+        { role: "toggleDevTools" },
+        { type: "separator" },
+      ];
+
   // View Menu
   template.push({
     label: "View",
     submenu: [
-      { role: "reload" },
-      { role: "forceReload" },
-      { role: "toggleDevTools" },
-      { type: "separator" },
+      ...devSubmenu,
       { role: "resetZoom" },
       { role: "zoomIn" },
       { role: "zoomOut" },


### PR DESCRIPTION
Asana: https://app.asana.com/0/1204304663633261/1204470021496297

Basically don't show the developer tools / reload menu items that make it feel more like a browser than an app.