### PR TITLE
Add MacOS Signing certificate script

### DIFF
--- a/scripts/add-macos-cert.sh
+++ b/scripts/add-macos-cert.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+KEY_CHAIN=build.keychain
+MACOS_CERT_P12_FILE=certificate.p12
+
+# Recreate the certificate from the secure environment variable
+echo $MACOS_CERT_P12 | base64 --decode > $MACOS_CERT_P12_FILE
+
+# Create a keychain
+security create-keychain -p actions $KEY_CHAIN
+
+# Make the keychain the default so identities are found
+security default-keychain -s $KEY_CHAIN
+
+# Unlock the keychain
+security unlock-keychain -p actions $KEY_CHAIN
+
+# Import the cert to the keychain
+security import $MACOS_CERT_P12_FILE -k $KEY_CHAIN -P $MACOS_CERT_PASSWORD -T /usr/bin/codesign;
+
+security set-key-partition-list -S apple-tool:,apple: -s -k actions $KEY_CHAIN
+
+# Remove certs
+rm -rf *.p12


### PR DESCRIPTION
Breaking this apart from https://github.com/replit/desktop/pull/1 because we're going to need this script for generating the MacOS certificate used to sign the app securely in GH actions.

See Electron Fiddle [script](https://github.com/electron/fiddle/blob/b7478bf92129e8d44b00b86e5b33912cce17f11d/tools/add-macos-cert.sh) for reference