### PR TITLE
bring back 'toggle developer tools' on production builds

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,3 +35,6 @@ export const baseUrl = process.env.USE_LOCAL_URL
 
 // https://www.electronjs.org/docs/latest/api/app#appispackaged-readonly
 export const isProduction = app.isPackaged;
+
+// do we show the dev submenu ("Reload", "Toggle Developer Tools") also on production builds
+export const isDevSubmenuAlwaysVisible = true;

--- a/src/createMenu.ts
+++ b/src/createMenu.ts
@@ -6,7 +6,7 @@ import {
   MenuItem,
   MenuItemConstructorOptions,
 } from "electron";
-import { baseUrl, isProduction } from "./constants";
+import { baseUrl, isDevSubmenuAlwaysVisible, isProduction } from "./constants";
 import { createFullWindow, createSplashScreenWindow } from "./createWindow";
 import { isMac } from "./platform";
 
@@ -92,14 +92,15 @@ export function createApplicationMenu(): Menu {
     ],
   });
 
-  const devSubmenu = isProduction
-    ? []
-    : [
-        { role: "reload" },
-        { role: "forceReload" },
-        { role: "toggleDevTools" },
-        { type: "separator" },
-      ];
+  const devSubmenu =
+    !isProduction || isDevSubmenuAlwaysVisible
+      ? [
+          { role: "reload" },
+          { role: "forceReload" },
+          { role: "toggleDevTools" },
+          { type: "separator" },
+        ]
+      : [];
 
   // View Menu
   template.push({


### PR DESCRIPTION
# Why

Asana: https://app.asana.com/0/1204365477281677/1204549115725978

# What changed

Added a switch to force developer tool menus to be visible on production builds

# Test plan 

Run the production app, View->Toggle Developer Tools is now visible.
