### PR TITLE
use env var for url to load from

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint -c .eslintrc --ext .ts ./src",
     "ci": "npm-run-all --parallel build lint",
     "start": "pnpm build && electron-forge start",
-    "start:local": "pnpm build && USE_LOCAL_URL=true electron-forge start",
+    "start:local": "pnpm build && cross-env REPLIT_URL=http://localhost:3000 electron-forge start",
+    "start:staging": "pnpm build && cross-env REPLIT_URL=https://staging.replit.com/ electron-forge start",
     "package": "electron-forge package",
     "publish": "electron-forge publish",
     "make": "pnpm build && electron-forge make"
@@ -29,6 +30,7 @@
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "cpy": "^9.0.1",
+    "cross-env": "^7.0.3",
     "electron": "^24.0.0",
     "electron-winstaller": "^5.1.0",
     "eslint": "^7.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ specifiers:
   '@typescript-eslint/parser': ^4.33.0
   conf: 10.2.0
   cpy: ^9.0.1
+  cross-env: ^7.0.3
   electron: ^24.0.0
   electron-squirrel-startup: ^1.0.0
   electron-store: ^8.1.0
@@ -42,6 +43,7 @@ devDependencies:
   '@typescript-eslint/eslint-plugin': 4.33.0_s2qqtxhzmb7vugvfoyripfgp7i
   '@typescript-eslint/parser': 4.33.0_jofidmxrjzhj7l6vknpw5ecvfe
   cpy: 9.0.1
+  cross-env: 7.0.3
   electron: 24.1.1
   electron-winstaller: 5.1.0
   eslint: 7.32.0
@@ -1382,6 +1384,14 @@ packages:
       nested-error-stacks: 2.1.1
       p-filter: 3.0.0
       p-map: 5.5.0
+    dev: true
+
+  /cross-env/7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
     dev: true
 
   /cross-spawn-windows-exe/1.2.0:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,9 +29,7 @@ export const macAppIcon = nativeImage.createFromPath(
 
 export const preloadScript = path.join(__dirname, "preload.js");
 
-export const baseUrl = process.env.USE_LOCAL_URL
-  ? `http://localhost:3000`
-  : `https://replit.com`;
+export const baseUrl = process.env.REPLIT_URL || "https://replit.com";
 
 // https://www.electronjs.org/docs/latest/api/app#appispackaged-readonly
 export const isProduction = app.isPackaged;


### PR DESCRIPTION
# Why

Asana: https://app.asana.com/0/1204304663633261/1204549114344638

# What changed

- instead of `USE_LOCAL_URL` we now have `REPLIT_URL`
- added `cross-env` so this also works when testing on Windows

# Test plan 

- `pnpm start:local` to start off localhost
- `pnpm start:staging` to use staging URL

