### PR TITLE
bring back dev tools menu

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,3 @@ export const baseUrl = process.env.USE_LOCAL_URL
 
 // https://www.electronjs.org/docs/latest/api/app#appispackaged-readonly
 export const isProduction = app.isPackaged;
-
-// do we show the dev submenu ("Reload", "Toggle Developer Tools") also on production builds
-export const isDevSubmenuAlwaysVisible = true;

--- a/src/createMenu.ts
+++ b/src/createMenu.ts
@@ -6,7 +6,7 @@ import {
   MenuItem,
   MenuItemConstructorOptions,
 } from "electron";
-import { baseUrl, isDevSubmenuAlwaysVisible, isProduction } from "./constants";
+import { baseUrl } from "./constants";
 import { createFullWindow, createSplashScreenWindow } from "./createWindow";
 import { isMac } from "./platform";
 
@@ -92,21 +92,14 @@ export function createApplicationMenu(): Menu {
     ],
   });
 
-  const devSubmenu =
-    !isProduction || isDevSubmenuAlwaysVisible
-      ? [
-          { role: "reload" },
-          { role: "forceReload" },
-          { role: "toggleDevTools" },
-          { type: "separator" },
-        ]
-      : [];
-
   // View Menu
   template.push({
     label: "View",
     submenu: [
-      ...devSubmenu,
+      { role: "reload" },
+      { role: "forceReload" },
+      { role: "toggleDevTools" },
+      { type: "separator" },
       { role: "resetZoom" },
       { role: "zoomIn" },
       { role: "zoomOut" },


### PR DESCRIPTION
# Why

Asana: https://app.asana.com/0/1204365477281677/1204549115725978

# What changed

Brought the menu items back.

# Test plan 

Run the production app, View->Toggle Developer Tools is now visible.
