### PR TITLE
Add more detailed build, dev, and release instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ If you need to build a production version of the app, you can run:
 pnpm make
 ```
 
-You can then launch a packaged version of the app (needed to test certain features like auto-updating) by running the outputted binary locally (e.g. on an M1 Mac: `./out/Replit-darwin-arm64/Replit.app/Contents/MacOS/Replit`)
+You can then launch a packaged version of the app (needed to test certain features like auto-updating) by running the outputted binary locally (e.g. on an M1 Mac: `./out/Replit-darwin-arm64/Replit.app/Contents/MacOS/Replit`).
+
+To test your changes on other platforms, we recommend using a Virtual Machine host like [UTM](https://mac.getutm.app).
 
 ## Release
 


### PR DESCRIPTION
# Why

The README was looking pretty empty. Have been meaning to transfer all the knowledge in my head into written form so that others can more easily contribute.

# What changed

Add more detail on how to start, release, and sign the app.

# Test plan 

👀 https://github.com/replit/desktop/tree/%40sergeichestakov/readme
