### PR TITLE
open a repl on the same monitor as the mouse cursor

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -26,10 +26,12 @@ function createStore() {
       store.set(keys.BOUNDS, bounds);
     },
     getBounds(): Rectangle {
-      return store.get(
-        keys.BOUNDS,
-        screen.getPrimaryDisplay().workArea
-      ) as Rectangle;
+      // We're assuming that the active screen is the one with the mouse cursor.
+      // This fixes the bug where opening a Repl from a Splash Screen opens it on some other display.
+      const mousePosition = screen.getCursorScreenPoint();
+      const mouseScreen = screen.getDisplayNearestPoint(mousePosition);
+
+      return store.get(keys.BOUNDS, mouseScreen.workArea) as Rectangle;
     },
   };
 }


### PR DESCRIPTION
# Why

Asana: https://app.asana.com/0/1204304663633261/1204566045937355

We're using a "primary display" to open a new window, which might differ from where the splash screen is.

# What changed

Instead of using "primary display" we're going to assume that the "active display" is where the mouse is and use it for opening a new window (only if we haven't stored the last window bounds before!).

# Test plan 

- have two displays
- clear the stored persisted values
- open the desktop app
- move the splash screen to a secondary (non-primary!) display
- click on the Repl -- it should open on the current monitor (the one where the mouse is)
