### PR TITLE
Expose native app version to web client

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -3,6 +3,7 @@ import {
   BrowserWindowConstructorOptions,
   screen,
   shell,
+  app,
 } from "electron";
 import {
   appIcon as icon,
@@ -30,6 +31,7 @@ function createBaseWindow({
   const window = new BrowserWindow({
     webPreferences: {
       preload,
+      additionalArguments: [`--app-version=${app.getVersion()}`],
       scrollBounce,
     },
     title,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -15,6 +15,14 @@ enum events {
   LOGOUT = "LOGOUT",
 }
 
+// Passed in as an entry to the `additionalArguments` array in `webPreferences`
+const versionArg = process.argv.find((arg) => arg.includes("app-version"));
+
+if (versionArg) {
+  const [, version] = versionArg.split("=");
+  contextBridge.exposeInMainWorld("desktopAppVersion", version);
+}
+
 // Set `window.isDesktopApp`
 contextBridge.exposeInMainWorld("isDesktopApp", true);
 


### PR DESCRIPTION
# Why

In order to ensure that we keep the web app backwards compatible and resilient to native API changes we first need to know which version of the native app we are running from within the web client / browser window so that we can check against this and fallback if we're on an older version without a certain API we need.

See [Asana task](https://app.asana.com/0/0/1204604313028963/f).

# What changed

Expose native app version to web client.

Open to ways of doing this better but as far as i can tell, this is the only way to reliably expose the version in a synchronous way (e.g. without the back and forth of using IPC). When running the app locally, there is also the `npm_packager_version` env var set but I don't think that is set when running in a packaged context.

We should also probably follow up and unify the API at some point (rather than have separate globals like `isDesktopApp` and `desktopAppVersion`) but we can defer this until we have a better approach.

# Test plan 

- Open up the native app
- Open the devtools
- `console.log(window.desktopAppVersion)` => outputs the version in `package.json`
