### PR TITLE
Update splash screen redirect to reflect new landing page name

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -88,7 +88,7 @@ interface WindowProps {
 export function createSplashScreenWindow(props?: WindowProps): void {
   const url =
     props?.url ||
-    `${baseUrl}/login?isInDesktopApp=true&goto=/desktop?isInDesktopApp=true`;
+    `${baseUrl}/login?isInDesktopApp=true&goto=/desktopApp/landingPage?isInDesktopApp=true`;
 
   const window = createBaseWindow({
     url,


### PR DESCRIPTION
# Why

We're changing the name here: https://github.com/replit/repl-it-web/pull/32253 so we should reflect that in the native client since we're going to deprecate and remove the previous route soon.

# What changed

Update splash screen redirect to reflect new landing page name (`/desktopApp/landingPage` instead of `/desktop`).

# Test plan 

`pnpm start:local` loads the splash screen as expected when that branch in web is checked out.
