### PR TITLE
Update login page URL to new app-specific page

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -86,9 +86,7 @@ interface WindowProps {
 }
 
 export function createSplashScreenWindow(props?: WindowProps): void {
-  const url =
-    props?.url ||
-    `${baseUrl}/login?isInDesktopApp=true&goto=/desktopApp/landingPage?isInDesktopApp=true`;
+  const url = props?.url || `${baseUrl}/desktopApp/login?isInDesktopApp=true`;
 
   const window = createBaseWindow({
     url,

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,7 @@ app.whenReady().then(() => {
 
   // When logging out we have to close all the windows, and do the actual logout navigation in a splash window
   ipcMain.on(events.LOGOUT, () => {
-    const url = `${baseUrl}/logout?goto=/login?isInDesktopApp=true`;
+    const url = `${baseUrl}/logout?goto=/desktopApp/login?isInDesktopApp=true`;
 
     BrowserWindow.getAllWindows().forEach((win) => win.close());
     createSplashScreenWindow({ url });


### PR DESCRIPTION
# Why

Follow up to https://github.com/replit/repl-it-web/pull/32271, we're adding a new desktop-app-specific login page so we should update the URL in the native client to reference that.

See [Asana task](https://app.asana.com/0/1204365477281677/1204604319642888/f).

# What changed

Update login page URL to new app-specific page. Note this means we don't need a second `goto` here in the splash screen URL since that redirect will always happen.

# Test plan 

- `pnpm start:local` with above branch checked out
- Login page looks and works as expected
- Logging in works
- Logging out works
