### PR TITLE
Remove isInDesktopApp query param

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -86,7 +86,7 @@ interface WindowProps {
 }
 
 export function createSplashScreenWindow(props?: WindowProps): void {
-  const url = props?.url || `${baseUrl}/desktopApp/login?isInDesktopApp=true`;
+  const url = props?.url || `${baseUrl}/desktopApp/login`;
 
   const window = createBaseWindow({
     url,

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,13 +59,13 @@ app.whenReady().then(() => {
   });
 
   ipcMain.on(events.OPEN_REPL_WINDOW, (_, replSlug) => {
-    const url = `${baseUrl}${replSlug}?isInDesktopApp=true`;
+    const url = `${baseUrl}${replSlug}`;
     createFullWindow({ url });
   });
 
   // When logging out we have to close all the windows, and do the actual logout navigation in a splash window
   ipcMain.on(events.LOGOUT, () => {
-    const url = `${baseUrl}/logout?goto=/desktopApp/login?isInDesktopApp=true`;
+    const url = `${baseUrl}/logout?goto=/desktopApp/login`;
 
     BrowserWindow.getAllWindows().forEach((win) => win.close());
     createSplashScreenWindow({ url });


### PR DESCRIPTION
# Why

This query param will be redundant and unnecessary once https://github.com/replit/repl-it-web/pull/32319 has landed and we are using a user-agent based approach to determine if we're in a desktop app context.

# What changed

Remove isInDesktopApp query param

# Test plan 

- `pnpm start:local` with the above branch checked out
- Desktop app splash screen and repl window custom UI still load as expected w no flashes.
