### PR TITLE
Add iconURL to Squirrel maker config

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -43,7 +43,7 @@ module.exports = {
       name: "@electron-forge/maker-squirrel",
       config: {
         setupIcon: "./assets/logo.ico",
-        iconURL: "https://replit.com/public/images/icon.ico",
+        iconURL: "https://replit.com/public/images/logo.ico",
         certificateFile: process.env.WINDOWS_CERTIFICATE_FILE,
         certificatePassword: process.env.WINDOWS_CERTIFICATE_PASSWORD,
       },


### PR DESCRIPTION
# Why

Follow up to https://github.com/replit/repl-it-web/pull/32362 (will merge this once that commit is deployed). We need to set this field to a publicly accessible https link to an ico file that contains our logo. Otherwise, the default Electron logo will still be displayed in the control panel and installed apps page on Windows.

See [Asana task](https://app.asana.com/0/1204365477281677/1204630711161960/f).

# What changed

Add iconURL to Squirrel maker config

# Test plan 

Should see our logo instead of Electron logo in Control Panel after installing the next release
