### PR TITLE
Capture auto-update errors in Sentry

### DIFF
--- a/src/checkForUpdates.ts
+++ b/src/checkForUpdates.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/electron";
 import { app, autoUpdater, dialog } from "electron";
 import { isProduction } from "./constants";
 import { isLinux, isWindows } from "./platform";
@@ -49,6 +50,14 @@ export default function checkForUpdates(): void {
   autoUpdater.on("error", (message) => {
     console.error("There was a problem updating the application");
     console.error(message);
+
+    const error = new Error("Failed to auto-update the application");
+
+    Sentry.captureException(error, {
+      extra: {
+        message,
+      },
+    });
   });
 
   autoUpdater.checkForUpdates();


### PR DESCRIPTION
# Why

Now that auto-updating works on both MacOS and Windows, we should have visibility into when it fails since this could happen for a variety of reasons (including our update server being down) and should be fixed ASAP.

# What changed

Capture auto-update errors in Sentry

# Test plan 

Keep an eye on Sentry after external beta rollout
