### PR TITLE
Bypass cache when loading remote URL

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -76,7 +76,10 @@ function createBaseWindow({
     }
   });
 
-  window.loadURL(url);
+  // Bypass the browser's cache when initially loading the remote URL
+  // in order to ensure that we load the latest web build.
+  // See: https://github.com/electron/electron/issues/1360#issuecomment-156506130
+  window.loadURL(url, { extraHeaders: "pragma: no-cache\n" });
 
   return window;
 }


### PR DESCRIPTION
# Why

We discovered a few issues likely related to loading a stale web build from Electron's default browser cache (e.g. [this](https://replit.slack.com/archives/C0509G0FJNL/p1684524965878249) and [this](https://replit.slack.com/archives/C0509G0FJNL/p1684761978179159) report).

Passing in this extra header should fix the problem. See: https://github.com/electron/electron/issues/1360#issuecomment-156506130

# What changed

Bypass cache when loading remote URL via `pragma: no-cache` header.

# Test plan 

Should stop seeing reports of caching issues
