### PR TITLE
Update top level api key exposed in preload script

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -20,15 +20,13 @@ enum events {
 // Passed in as an entry to the `additionalArguments` array in `webPreferences`
 const versionArg = process.argv.find((arg) => arg.includes("app-version"));
 
-if (versionArg) {
-  const [, version] = versionArg.split("=");
-  contextBridge.exposeInMainWorld("desktopAppVersion", version);
+if (!versionArg) {
+  throw new Error("Expected app-version argument");
 }
 
-// Set `window.isDesktopApp`
-contextBridge.exposeInMainWorld("isDesktopApp", true);
+const [, version] = versionArg.split("=");
 
-contextBridge.exposeInMainWorld("desktopAppApi", {
+contextBridge.exposeInMainWorld("replitDesktop", {
   closeCurrentWindow: () => ipcRenderer.send(events.CLOSE_CURRENT_WINDOW),
   openReplWindow: (replSlug: string) =>
     ipcRenderer.send(events.OPEN_REPL_WINDOW, replSlug),
@@ -37,4 +35,5 @@ contextBridge.exposeInMainWorld("desktopAppApi", {
   openExternalUrl: (url: string) =>
     ipcRenderer.send(events.OPEN_EXTERNAL_URL, url),
   logout: () => ipcRenderer.send(events.LOGOUT),
+  version,
 });


### PR DESCRIPTION
# Why

Szymon and I talked about changing the top level api key exposed to web since the term "api" no longer makes sense as not everything we expose is necessarily a part of the API (e.g. static fields like "version").

We also just generally want to consolidate the API as there are currently three fields being exposed. The `desktopAppVersion` we can move into the new top level field and the `isDesktopApp` field we can remove entirely since that's made redundant by the other fields and we are now using a user-agent based approach to determine if we're in a desktop app context. See [Asana task](https://app.asana.com/0/1204365477281677/1204630711161953/f).

# What changed

- `window.desktopAppApi` -> `window.replitDesktop`
- Move version field under `replitDesktop` and make the `app-version` arg required in the preload script
- Remove the redundant `isDesktopApp` field.

# Test plan 

Launch the native app via `pnpm start`. Then open the dev tools console:
- `window.desktopAppApi` -> undefined
- `window.isDesktopApp` -> undefined
- `window.replitDesktop` -> contains the object that was prev under `desktopAppApi` + the version
- `window.replitDesktop.version` -> "0.0.2"
