### PR TITLE
hide menubar on windows and linux

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -24,18 +24,16 @@ function createBaseWindow({
 }: BaseWindowProps): BrowserWindow {
   const backgroundColor = store.getLastSeenBackgroundColor();
 
-  // MacOS only
-  const scrollBounce = true;
-
   const window = new BrowserWindow({
     webPreferences: {
       preload,
       additionalArguments: [`--app-version=${app.getVersion()}`],
-      scrollBounce,
+      scrollBounce: true, // MacOS only
     },
     title,
     icon,
     backgroundColor,
+    autoHideMenuBar: true, // Window & Linux only, hides the menubar unless `Alt` is held
     ...constructorOptions,
   });
 


### PR DESCRIPTION
# Why

Asanas:
- https://app.asana.com/0/1204365477281677/1204519273224413
- https://app.asana.com/0/1204365477281677/1204529541921604

Saving ~20px that we can bring back if Alt is held: https://www.electronjs.org/docs/latest/api/browser-window#winautohidemenubar

# What changed

Added `autoHideMenuBar: true`.

# Test plan 

Open the desktop app on Linux and Windows, the menubar is no longer there, unless you hold `Alt`.
