### PR TITLE
Handle authComplete deeplinks

### DIFF
--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -22,7 +22,7 @@ function handleDeeplink(deeplink: string): void {
 
   const url = new URL(deeplink);
 
-  // Remove trailing :
+  // Remove trailing ":"
   if (url.protocol.slice(0, -1) !== protocol) {
     throw new Error("Invalid protocol");
   }


### PR DESCRIPTION
# Why

We need to add support for `authComplete` deeplinks in order to enable passing in an auth token to the native app as part of the new login flow. See description and diagram here for more detail: https://github.com/replit/repl-it-web/pull/32625

# What changed

Handle authComplete deeplinks in the native app with the following format: `replit://authComplete?authToken={...}`

This will open up the `desktopApp/login` page with the same auth token passed in as a query param. That token will then be exchanged for a valid session ID via the new `desktopAppSessionId` GQL query introduced in the above PR which will be set as the value of the `connect.sid` cookie (will follow up with this in a subsequent PR).

Note that I was originally intending to fetch the session ID from the main process via a REST endpoint but opted to do it in on the web side in the renderer process so that we can show a loading state while the session ID is being fetched instead of nothing and to handle any errors that may come up during the process.

# Test plan 

- Click a link with the format `replit://authComplete?authToken={...}`
- See splash screen open up with login page if logged out and landing page if logged in
- Open up a link with the format `replit://invalidPath`
- See nothing happen, log in the console for unrecognized hostname
