### PR TITLE
Don't show full release notes during auto-update, force restart

### DIFF
--- a/src/checkForUpdates.ts
+++ b/src/checkForUpdates.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/electron";
 import { app, autoUpdater, dialog } from "electron";
 import { isProduction } from "./constants";
-import { isLinux, isWindows } from "./platform";
+import { isLinux } from "./platform";
 
 const server = "https://desktop-app-releases.replit.app";
 const url = `${server}/update/${process.platform}/${app.getVersion()}`;
@@ -29,13 +29,12 @@ export default function checkForUpdates(): void {
     return;
   }
 
-  autoUpdater.on("update-downloaded", (_event, releaseNotes, releaseName) => {
+  autoUpdater.on("update-downloaded", () => {
     const dialogOpts = {
       type: "info",
-      buttons: ["Restart", "Later"],
+      buttons: ["Restart"],
       title: "Application Update",
-      // On Windows only releaseName is available.
-      message: isWindows() ? releaseName : releaseNotes,
+      message: "New Update Available",
       detail:
         "A new version has been downloaded. Restart the application to apply the updates.",
     };


### PR DESCRIPTION
# Why

After a few internal releases so far, I realized that our release notes are not very user-friendly (currently we generate them based on the commits that have landed). It's also not comprehensive as most of the updates happen continuously on web anyways. We should just show a more generic message for now rather than leak internal implementation details until we figure out how to better summarize changes in a generic way while still keeping "releases" informative for us internally.

Separately, I don't think we want to give users a choice as far as whether or not they update anymore, at least not for the beta as we'll likely be making backwards-incompatible changes often and want to ensure users are no longer on stale clients as soon as an update is available.

See [Asana task](https://app.asana.com/0/1204365477281677/1204630711161958/f).

# What changed

- Don't show full release notes after auto-update
- Force restart after update

New dialog box (except will obv show our logo once the app is packaged):

<img width="259" alt="Screenshot 2023-05-30 at 11 06 10 AM" src="https://github.com/replit/desktop/assets/24947334/fe57c8d2-7b44-46c2-9de0-766aeb7ac710">


# Test plan 

- Open up dialog box
- See generic message and only one button to restart
