### PR TITLE
Update update release server base URL

### DIFF
--- a/src/checkForUpdates.ts
+++ b/src/checkForUpdates.ts
@@ -3,7 +3,7 @@ import { app, autoUpdater, dialog } from "electron";
 import { isProduction } from "./constants";
 import { isLinux } from "./platform";
 
-const server = "https://desktop-app-releases.replit.app";
+const server = "https://desktop.replit.com";
 const url = `${server}/update/${process.platform}/${app.getVersion()}`;
 
 export default function checkForUpdates(): void {


### PR DESCRIPTION
# Why

Updating the auto-update URL to reflect the fact that we have now pointed `desktop.replit.com` to the update release server deployment. More context [on Slack](https://replit.slack.com/archives/C0509G0FJNL/p1685470334503509).

# What changed

Update update release server base URL

# Test plan 

- Add logs to `checkForUpdates` function
- Build and package the app via `pnpm make`
- Verify checking for updates works as expected
- Should see update prompt after next release is published
