### PR TITLE
Better typing for dialog type field

### DIFF
--- a/src/checkForUpdates.ts
+++ b/src/checkForUpdates.ts
@@ -31,7 +31,7 @@ export default function checkForUpdates(): void {
 
   autoUpdater.on("update-downloaded", () => {
     const dialogOpts = {
-      type: "info",
+      type: "info" as const,
       buttons: ["Restart"],
       title: "Application Update",
       message: "New Update Available",

--- a/src/createMenu.ts
+++ b/src/createMenu.ts
@@ -28,7 +28,7 @@ const openReplFromClipboardMenuItem = {
       createFullWindow({ url: clipboardText });
     } else {
       dialog.showMessageBox({
-        type: "warning",
+        type: "warning" as const,
         message: "The URL in Clipboard is not a Repl URL",
       });
     }


### PR DESCRIPTION
# Why

Switched to a newer version of Node and saw this type error (string not assignable to union of const strings). Unclear why it's not showing up in older versions (e.g. `18.12.0`) but we should probably do this anyways

# What changed

Better typing for dialog type field (const string)

# Test plan 

No TS errors - build works as expected
