### PR TITLE
Package the app using asar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,21 +9,9 @@ on:
       - main
 
 jobs:
-  make:
-    name: Make (${{ matrix.os }} - ${{ matrix.arch }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ macOS-latest, ubuntu-latest, windows-latest ]
-        arch: [ x64, arm64 ]
-        # Publishing artifacts for multiple Windows architectures has
-        # a bug which can cause the wrong architecture to be downloaded
-        # for an update, so until that is fixed, only build Windows x64
-        exclude:
-        - os: windows-latest
-          arch: arm64
-        - os: ubuntu-latest
-          arch: arm64
+  build:
+    name: Build and lint
+    runs-on: ubuntu-latest 
 
     steps:
       - uses: actions/checkout@v3
@@ -37,27 +25,5 @@ jobs:
           cache: pnpm
       - name: Install
         run: pnpm install
-      - name: Build
-        run: pnpm build
-      - name: Generate Windows code signing certificate 
-        if: matrix.os == 'windows-latest'
-        id: write_file
-        uses: timheuer/base64-to-file@v1.2
-        with:
-          fileName: 'windows-certificate.pfx'
-          encodedString: ${{ secrets.WINDOWS_CODESIGN_CERTIFICATE }}
-      - name: Generate MacOS code signing certificate
-        if: matrix.os == 'macOS-latest'
-        run: ./scripts/add-macos-cert.sh
-        env:
-          MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
-          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
-      - name: Make and Publish
-        run: pnpm run make --arch=${{ matrix.arch }}
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          WINDOWS_CERTIFICATE_FILE: ${{ steps.write_file.outputs.filePath }}
-          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Build and lint
+        run: pnpm run ci 


### PR DESCRIPTION
# Why

A beta user [pointed out](https://replit.slack.com/archives/C0509G0FJNL/p1685640396603109) that the source code was easily accessible in the distribution.

Packaging the app using asar will not fix the issue entirely (someone can still easily install the asar package and extract the `.asar` file) but will at least make it one step harder and mean we do not simply ship our source code as is. See [relevant docs](https://electron.github.io/electron-packager/main/interfaces/electronpackager.options.html#asar).

# What changed

Package the app using [asar](https://github.com/electron/asar).

# Test plan 

Locally run the following:
- `pnpm make`
- `unzip out/make/zip/darwin/arm64/` (or wherever the outputted zip file lives depending on your OS and arch)
- See `Replit.app/Contents/Resources/app.asar` instead of all of our unminified source code under `Replit.app/Contents/Resources/app/`

I also tested that `pnpm make` still works in CI in [this commit](https://github.com/replit/desktop/pull/48/commits/3da16b00251657fe0735bc27bc2b29b1b7841147).