### PR TITLE
Move IPC logic to its own module

### DIFF
--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -1,0 +1,41 @@
+import { BrowserWindow, ipcMain, shell } from "electron";
+import { createFullWindow, createSplashScreenWindow } from "./createWindow";
+import { baseUrl, events } from "./constants";
+
+/**
+ * Set listeners for IPC, or inter-process communication, events that are
+ * emitted by the renderer process via the API defined in the preload script.
+ *
+ * Should be called before the first browser window is opened.
+ *
+ * See relevant docs for more detail: https://www.electronjs.org/docs/latest/tutorial/ipc
+ */
+export function setIpcEventListeners(): void {
+  ipcMain.on(events.CLOSE_CURRENT_WINDOW, (event) => {
+    const senderWindow = BrowserWindow.getAllWindows().find(
+      (win) => win.webContents.id === event.sender.id
+    );
+    senderWindow.close();
+  });
+
+  ipcMain.on(events.OPEN_REPL_WINDOW, (_, replSlug) => {
+    const url = `${baseUrl}${replSlug}`;
+    createFullWindow({ url });
+  });
+
+  ipcMain.on(events.OPEN_SPLASH_SCREEN_WINDOW, () => {
+    createSplashScreenWindow();
+  });
+
+  ipcMain.on(events.OPEN_EXTERNAL_URL, (_, url) => {
+    shell.openExternal(url);
+  });
+
+  // When logging out we have to close all the windows, and do the actual logout navigation in a splash window
+  ipcMain.on(events.LOGOUT, () => {
+    const url = `${baseUrl}/logout?goto=/desktopApp/login`;
+
+    BrowserWindow.getAllWindows().forEach((win) => win.close());
+    createSplashScreenWindow({ url });
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,12 @@
-import { app, Menu, BrowserWindow, ipcMain, shell } from "electron";
-import { createFullWindow, createSplashScreenWindow } from "./createWindow";
-import { appName, baseUrl, events, macAppIcon } from "./constants";
+import { app, Menu, BrowserWindow } from "electron";
+import { createSplashScreenWindow } from "./createWindow";
+import { appName, macAppIcon } from "./constants";
 import { isMac } from "./platform";
 import { initSentry } from "./sentry";
 import { createApplicationMenu, createDockMenu } from "./createMenu";
 import checkForUpdates from "./checkForUpdates";
 import { registerDeeplinkProtocol, setOpenDeeplinkListeners } from "./deeplink";
+import { setIpcEventListeners } from "./ipc";
 
 initSentry();
 
@@ -40,6 +41,7 @@ app.whenReady().then(() => {
   }
 
   setOpenDeeplinkListeners();
+  setIpcEventListeners();
   createSplashScreenWindow();
   checkForUpdates();
 
@@ -49,34 +51,6 @@ app.whenReady().then(() => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createSplashScreenWindow();
     }
-  });
-
-  ipcMain.on(events.CLOSE_CURRENT_WINDOW, (event) => {
-    const senderWindow = BrowserWindow.getAllWindows().find(
-      (win) => win.webContents.id === event.sender.id
-    );
-    senderWindow.close();
-  });
-
-  ipcMain.on(events.OPEN_REPL_WINDOW, (_, replSlug) => {
-    const url = `${baseUrl}${replSlug}`;
-    createFullWindow({ url });
-  });
-
-  ipcMain.on(events.OPEN_SPLASH_SCREEN_WINDOW, () => {
-    createSplashScreenWindow();
-  });
-
-  ipcMain.on(events.OPEN_EXTERNAL_URL, (_, url) => {
-    shell.openExternal(url);
-  });
-
-  // When logging out we have to close all the windows, and do the actual logout navigation in a splash window
-  ipcMain.on(events.LOGOUT, () => {
-    const url = `${baseUrl}/logout?goto=/desktopApp/login`;
-
-    BrowserWindow.getAllWindows().forEach((win) => win.close());
-    createSplashScreenWindow({ url });
   });
 });
 


### PR DESCRIPTION
# Why

Just some refactoring. Better separation of concerns especially since the IPC logic will increase quite a bit over time as we add more complexity / capabilities to the native app so deservers its own module.

Also realized that we set the listeners _after_ opening the initial browser window. In practice not a huge deal but could in theory lead to missed events.

# What changed

- Move IPC logic to its own module
- Set listeners _before_ opening the window

# Test plan 

App works as expected
