### PR TITLE
Differentiate between M1 and Intel Macs during autoupdate

### DIFF
--- a/src/checkForUpdates.ts
+++ b/src/checkForUpdates.ts
@@ -1,10 +1,13 @@
 import * as Sentry from "@sentry/electron";
 import { app, autoUpdater, dialog } from "electron";
 import { isProduction } from "./constants";
-import { isLinux } from "./platform";
+import { isLinux, isMac } from "./platform";
 
+// We need this to differentiate between M1 and Intel Macs
+const platform =
+  isMac() && process.arch === "arm64" ? "darwin_arm64" : process.platform;
 const server = "https://desktop.replit.com";
-const url = `${server}/update/${process.platform}/${app.getVersion()}`;
+const url = `${server}/update/${platform}/${app.getVersion()}`;
 
 export default function checkForUpdates(): void {
   // The app must be packaged in order to check for updates.


### PR DESCRIPTION
# Why

It looks like we always downloaded the latest Intel version of the app for Mac regardless of if you are on an M1 or Intel Mac.

This may be what's leading to the reports of slow down after auto-updating the app. See [Linear task](https://linear.app/replit/issue/WS-284/fix-autoupdate-on-intel-macs).

# What changed

Differentiate between M1 and Intel Macs during auto-update

# Test plan 

- Autoupdating still works as expected for Mac
- Should get fewer reports of slowdown after update
