### PR TITLE
Update default splash screen URL to new auth page

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -87,7 +87,7 @@ interface WindowProps {
 }
 
 export function createSplashScreenWindow(props?: WindowProps): BrowserWindow {
-  const url = props?.url || `${baseUrl}/desktopApp/login`;
+  const url = props?.url || `${baseUrl}/desktopApp/auth`;
 
   const window = createBaseWindow({
     url,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -33,7 +33,7 @@ export function setIpcEventListeners(): void {
 
   // When logging out we have to close all the windows, and do the actual logout navigation in a splash window
   ipcMain.on(events.LOGOUT, () => {
-    const url = `${baseUrl}/logout?goto=/desktopApp/login`;
+    const url = `${baseUrl}/logout?goto=/desktopApp/auth`;
 
     BrowserWindow.getAllWindows().forEach((win) => win.close());
     createSplashScreenWindow({ url });


### PR DESCRIPTION
# Why

Now that we've landed all of the changes we need to support the new auth flow (context: https://github.com/replit/repl-it-web/pull/32625) we should point the native app to the new page to be able to kick off the flow.

# What changed

Desktop app opens `/desktopApp/auth` instead of `/desktopApp/login` when first launched and logged out.

# Test plan 

- `pnpm start` (when not logged in)
- See new auth page
- Login works as expected
- Log out
- See new auth page again
