### PR TITLE
Revert "Update default splash screen URL to new auth page"

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -87,7 +87,7 @@ interface WindowProps {
 }
 
 export function createSplashScreenWindow(props?: WindowProps): BrowserWindow {
-  const url = props?.url || `${baseUrl}/desktopApp/auth`;
+  const url = props?.url || `${baseUrl}/desktopApp/login`;
 
   const window = createBaseWindow({
     url,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -33,7 +33,7 @@ export function setIpcEventListeners(): void {
 
   // When logging out we have to close all the windows, and do the actual logout navigation in a splash window
   ipcMain.on(events.LOGOUT, () => {
-    const url = `${baseUrl}/logout?goto=/desktopApp/auth`;
+    const url = `${baseUrl}/logout?goto=/desktopApp/login`;
 
     BrowserWindow.getAllWindows().forEach((win) => win.close());
     createSplashScreenWindow({ url });


### PR DESCRIPTION
Reverts replit/desktop#55

Doesn't seem to work properly on Windows/Linux. Also should probably handle the error case and implement some sort of timeout