### PR TITLE
document API versioning approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Electron app communicates with the web frontend through the `replitDesktop` 
 
 We're following a set of principles inspired by protobuf versioning:
 - don't remove the existing APIs
-- don't modify existing API call signatures; instead create a new API with a number added to the end, for example: `replitDesktop.logout2(NEW_ARGUMENTS)`
+- don't modify existing API call signatures
 - adding new APIs in the Electron app is ok, in the web client these should be optionally typed, and checked for existence dynamically (`if ('logout2' in replitDesktop) { ... }`)
 
 ## Release


### PR DESCRIPTION
# Why

Linear: https://linear.app/replit/issue/WS-296/write-down-how-we-do-api-versioning-in-the-readme-and-preload-code

We discussed the API versioning during onfsite, this PR adds what we decided to the README. I skipped the three-month deprecation for now, we can add this in later as we work on that code.

# What changed

Updated the README.

# Test plan 

Read the README.
