### PR TITLE
Fix deeplinking parsing logic in Windows

### DIFF
--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -76,7 +76,7 @@ export function setOpenDeeplinkListeners(): void {
   // See docs: https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app
   if (isWindows()) {
     app.on("second-instance", (_event, commandLine) => {
-      // the commandLine is array of strings in which last element is the deep link url
+      // the commandLine is an array of strings in which the last element is the deep link url
       const url = commandLine.pop();
 
       handleDeeplink(url);


### PR DESCRIPTION
# Why

Realized that I was parsing the URL wrong on Windows 🤦 See [docs](https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app).

# What changed

Fix deeplink parsing in Windows

# Test plan 

- Open app on Windows
- Deeplinking works
