### PR TITLE
Focus/restore auth window on auth token received deeplink

### DIFF
--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -68,6 +68,12 @@ function handleAuthComplete(authToken: string) {
     return;
   }
 
+  if (authWindow.isMinimized()) {
+    authWindow.restore();
+  }
+
+  authWindow.focus();
+
   authWindow.webContents.send(events.AUTH_TOKEN_RECEIVED, authToken);
 }
 


### PR DESCRIPTION
# Why

We should focus/restore the window during the auth process. Also matches what [the docs](https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app) recommend.

# What changed

Focus/restore auth window on auth token received deeplink

# Test plan 

- Trigger new auth flow
- See auth window focused when deeplink is received
