### PR TITLE
Allow multiple AUTH_TOKEN_RECEIVED events to fire

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -52,7 +52,7 @@ contextBridge.exposeInMainWorld("replitDesktop", {
       callback(token);
     }
 
-    ipcRenderer.once(events.AUTH_TOKEN_RECEIVED, listener);
+    ipcRenderer.on(events.AUTH_TOKEN_RECEIVED, listener);
 
     return () => {
       ipcRenderer.removeListener(events.AUTH_TOKEN_RECEIVED, listener);


### PR DESCRIPTION
# Why

It occurred to me that we actually do want to support this event firing more than once in the case where the first request fails and we want to retry the auth process and issue a new token to the client. As such, we should support an arbitrary number of events firing for a given listener.

# What changed

Allow multiple AUTH_TOKEN_RECEIVED events to fire (e.g. `once` -> `on`)

# Test plan 

- Test new auth flow (but ensure first request fails)
- Retrigger auth flow via retry button in auth page
- Should see another event fire with new auth token
