### PR TITLE
Fix deeplinking on Linux

### DIFF
--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow } from "electron";
-import { isWindows } from "./platform";
+import { isWindows, isLinux } from "./platform";
 import { baseUrl, events, protocol } from "./constants";
 import path from "path";
 import { createSplashScreenWindow } from "./createWindow";
@@ -72,9 +72,9 @@ function handleAuthComplete(authToken: string) {
 }
 
 export function setOpenDeeplinkListeners(): void {
-  // Windows fires a different event when deeplinks are opened
+  // Windows and Linux fire a different event when deeplinks are opened
   // See docs: https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app
-  if (isWindows()) {
+  if (isWindows() || isLinux()) {
     app.on("second-instance", (_event, commandLine) => {
       // the commandLine is array of strings in which last element is deep link url
       // the url str ends with /
@@ -86,7 +86,6 @@ export function setOpenDeeplinkListeners(): void {
     return;
   }
 
-  // Handle the protocol. In this case, we choose to show an Error Box.
   app.on("open-url", (_event, url) => {
     handleDeeplink(url);
   });


### PR DESCRIPTION
# Why

The Electron docs are, on again, incorrect [here](https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app#macos-and-linux-code). Linux fires the "second-instance" event like Windows does rather than the "open-url" event like MacOS when it receives a deeplink. Therefore, we need to ensure we set the correct handler on Linux so that the app can receive deeplinks.

# What changed

Fix deeplinking on Linux by listening for the "second-instance" event instead of the "open-url" event

# Test plan 

Deeplinking works as expected on Linux
