### PR TITLE
Revert "Revert "Update default splash screen URL to new auth page (#5…

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -88,7 +88,7 @@ interface WindowProps {
 }
 
 export function createSplashScreenWindow(props?: WindowProps): BrowserWindow {
-  const url = props?.url || `${baseUrl}/desktopApp/login`;
+  const url = props?.url || `${baseUrl}/desktopApp/auth`;
 
   const window = createBaseWindow({
     url,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -33,7 +33,7 @@ export function setIpcEventListeners(): void {
 
   // When logging out we have to close all the windows, and do the actual logout navigation in a splash window
   ipcMain.on(events.LOGOUT, () => {
-    const url = `${baseUrl}/logout?goto=/desktopApp/login`;
+    const url = `${baseUrl}/logout?goto=/desktopApp/auth`;
 
     BrowserWindow.getAllWindows().forEach((win) => win.close());
     createSplashScreenWindow({ url });


### PR DESCRIPTION
…5)" (#56)"

This reverts commit 06ba7275da0ecbfb34a03a4ecdfb4dfeab0ef905.

# Why

Same as https://github.com/replit/desktop/pull/55 (reverted in https://github.com/replit/desktop/pull/56).

Previously, I reverted the above commit because I realized that the new auth flow was not working on Linux and Windows. Turns out they both had issues with receiving deeplinks that I've since fixed which means this is unblocked.

# What changed

Update default logged out URL for splash screen from `desktopApp/login` to `desktopApp/auth` to enable the new auth flow in the native app

# Test plan 

New auth flow (and deeplinks) works on Mac, Windows, and Linux (both logged out and logged in in external browser and with email/password and OAuth login).
