### PR TITLE
Add make step that runs if config files are changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
           filters: |
             config:
               - package.json
+              - tsconfig.json
               - forge.config.js
 
   make:


### PR DESCRIPTION
# Why

As part of testing that the build doesn't break after each commit, we should also ensure that the make step works as expected on each platform we support any time we update the package.json or forge config since changing either of those has the potential to subtly break our ability to make and therefore publish artifacts (esp on platforms that we don't actively use like Windows). See [Linear](https://linear.app/replit/issue/WS-313/add-github-workflow-that-tests-build-for-prs-against-main-that-update).

Previously, I held off on this because running make takes a decently long time, but I think if we skip the signing process and conditionally run this only when config files are changed then it should be reasonable

# What changed

Add make step to build workflow for PRs against and pushes to main that is conditional on either `forge.config.js` or `package.json` changing (see relevant workflow [docs](https://github.com/dorny/paths-filter))

# Test plan 

New make workflow only runs when either of the above is changed
