### PR TITLE
Allow splash screen window to be resizable

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -90,19 +90,20 @@ interface WindowProps {
 export function createSplashScreenWindow(props?: WindowProps): BrowserWindow {
   const url = props?.url || `${baseUrl}/desktopApp/auth`;
 
+  const width = 480;
+  const height = 640;
+
   const window = createBaseWindow({
     url,
     constructorOptions: {
       frame: false,
-      resizable: false,
       minimizable: false,
       maximizable: false,
       fullscreen: false,
+      minWidth: width,
+      minHeight: height,
     },
   });
-
-  const width = 480;
-  const height = 640;
 
   const bounds = {
     ...store.getSplashScreenWindowBounds(),


### PR DESCRIPTION
# Why

It's been one of our most common complaints

# What changed

Allow splash screen window to be resizable (still has the same min height/width as before and also doesn't persist height across sessions)

# Test plan 

- Open app
- Resize splash screen window
