### PR TITLE
Revert "Allow splash screen window to be resizable"

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -90,20 +90,19 @@ interface WindowProps {
 export function createSplashScreenWindow(props?: WindowProps): BrowserWindow {
   const url = props?.url || `${baseUrl}/desktopApp/auth`;
 
-  const width = 480;
-  const height = 640;
-
   const window = createBaseWindow({
     url,
     constructorOptions: {
       frame: false,
+      resizable: false,
       minimizable: false,
       maximizable: false,
       fullscreen: false,
-      minWidth: width,
-      minHeight: height,
     },
   });
+
+  const width = 480;
+  const height = 640;
 
   const bounds = {
     ...store.getSplashScreenWindowBounds(),


### PR DESCRIPTION
Reverts replit/desktop#68

I've decided that we should hold off on this until we've implemented the new [home page mocks](https://www.figma.com/file/uEMoNOxlmKZX9IYiztEO7v/Desktop-App-Home?type=design&node-id=239%3A16514&mode=design&t=d7mwfEDYuJKcOQGV-1), which will have to be on a different page anyways, thus requiring a new build.

Therefore, we can keep the current splash screen a fixed size as is and update to be dynamic sizing once we've landed those changes