### PR TITLE
Set min width and height for browser windows

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -44,8 +44,8 @@ export function createWindow(props?: WindowProps): BrowserWindow {
     },
     title,
     icon,
-    minWidth: 875,
-    minHeight: 580,
+    minWidth: 500,
+    minHeight: 420,
     backgroundColor,
     autoHideMenuBar: true, // Window & Linux only, hides the menubar unless `Alt` is held
     ...platformStyling,


### PR DESCRIPTION
# Why

We want to set a min width/height for the app since the home page and workspace both don't look good on very small screens. Fixes WS-572.

# What changed

Set min width and height for browser windows

# Test plan 

- Open app
- Shrink really small
