### PR TITLE
Relative URL support in createWindow

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -18,9 +18,19 @@ interface WindowProps {
   url?: string;
 }
 
+const defaultUrl = `${baseUrl}/desktopApp/auth`;
+
+function createURL(url?: string) {
+  if (url) {
+    return url.startsWith("/") ? `${baseUrl}${url}` : url;
+  }
+
+  return defaultUrl;
+}
+
 export function createWindow(props?: WindowProps): BrowserWindow {
   const backgroundColor = store.getLastSeenBackgroundColor();
-  const url = props?.url || `${baseUrl}/desktopApp/auth`;
+  const url = createURL(props?.url);
 
   // For MacOS we use a hidden titlebar and move the traffic lights into the header of the interface
   // the corresponding CSS adjustments to enable that live in the repl-it-web repo!


### PR DESCRIPTION
# Why

Similar to https://github.com/replit/repl-it-web/pull/32881/ but for the `createWindow` API. think it's convenient to support relative URLs.

# What changed

Add relative URL support in createWindow API

# Test plan 

- Pass in a relative URL e.g. `/about` -> see `replit.com/about`
- Don't pass in any URL -> still works as expected by loading in the home page
