### PR TITLE
Support deeplinking to Repl

### DIFF
--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow } from "electron";
 import { isWindows, isLinux } from "./platform";
-import { baseUrl, protocol } from "./constants";
+import { baseUrl, protocol, workspaceUrlRegex } from "./constants";
 import path from "path";
 import { createWindow } from "./createWindow";
 import { events } from "./events";
@@ -29,13 +29,42 @@ function handleDeeplink(deeplink: string): void {
   }
 
   switch (url.hostname) {
-    case "authComplete":
+    case "authComplete": {
       handleAuthComplete(url.searchParams.get("authToken"));
 
       break;
-    default:
-      console.log("Unrecognized hostname");
+    }
+
+    case "repl": {
+      handleRepl(url.pathname);
+
+      break;
+    }
+
+    default: {
+      console.error("Unrecognized hostname");
+    }
   }
+}
+
+function handleRepl(url: string) {
+  if (!workspaceUrlRegex.test(url)) {
+    console.error("Expected URL of the format /@username/slug");
+
+    return;
+  }
+
+  const focused = BrowserWindow.getFocusedWindow();
+
+  if (focused) {
+    focused.loadURL(`${baseUrl}${url}`);
+
+    return;
+  }
+
+  createWindow({
+    url,
+  });
 }
 
 function handleAuthComplete(authToken: string) {


### PR DESCRIPTION
# Why

We want to support the ability to deeplink to a specific Repl in the desktop app.

Fixes WS-506

# What changed

The app now supports deeplinks of the following format: `replit://repl/@:username/:slug`

# Test plan 

- Visit `replit://repl/@username/slug` for valid combo of username, slug
- It navigates to that repl in the main window, if focused, or a new window otherwise
- Visit `replit://repl/abc`
- It doesn't work since that's not a valid URL
