### PR TITLE
Prevent navigation outside of supported pages

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,7 @@ export const workspaceUrlRegex = /^\/@\S+\/\S+/;
 
 export const homePage = "/desktopApp/home";
 export const authPage = "/desktopApp/auth";
+export const desktopAppPrefix = "/desktopApp";
 
 // https://www.electronjs.org/docs/latest/api/app#appispackaged-readonly
 export const isProduction = app.isPackaged;

--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -12,6 +12,7 @@ import {
   workspaceUrlRegex,
   homePage,
   authPage,
+  desktopAppPrefix,
 } from "./constants";
 import { events } from "./events";
 import { isMac } from "./platform";
@@ -119,11 +120,13 @@ export function createWindow(props?: WindowProps): BrowserWindow {
     const url = new URL(navigationUrl);
 
     const isReplit = url.origin === baseUrl;
-    const isSignup = url.pathname === "/signup";
-    const isSupport = url.pathname === "/support";
+    const isSupportedPage =
+      url.pathname.startsWith(desktopAppPrefix) ||
+      workspaceUrlRegex.test(url.pathname) ||
+      url.pathname === "/logout";
 
-    // Prevent navigation away from Replit
-    if (!isReplit || isSignup || isSupport) {
+    // Prevent navigation away from Replit or supported pages
+    if (!isReplit || !isSupportedPage) {
       event.preventDefault();
       shell.openExternal(navigationUrl);
     }


### PR DESCRIPTION
# Why

We don't want to allow arbitrary navigation outside supported pages in the desktop app. Currently, this is possibly by opening up the console and executing `window.location.href = "https://replit.com/"` which will take you to the home page.

Fixes WS-43

# What changed

Prevent navigation outside of supported pages (e.g. those that are prefixed with `/desktopApp`, the workspace, etc).

# Test plan 

- Try the above in the console
- It doesn't work
- Rest of the app works as expected
