### PR TITLE
Hide dev tools when packaged

### DIFF
--- a/src/createMenu.ts
+++ b/src/createMenu.ts
@@ -98,9 +98,8 @@ export function createApplicationMenu(): Menu {
     submenu: [
       { role: "reload" },
       { role: "forceReload" },
-      { role: "toggleDevTools" },
       // Don't expose dev tools in production
-      ...(!isProduction ? [{ type: "toggleDevTools" }] : []),
+      ...(!isProduction ? [{ role: "toggleDevTools" }] : []),
       { type: "separator" },
       { type: "separator" },
       { role: "togglefullscreen" },


### PR DESCRIPTION
# Why

Pretty self-explanatory. We don't want users using this. Initially it was helpful for debugging but now it's safe to remove

# What changed

Hide dev tools when packaged

# Test plan 

- Start app locally
- See dev tools menu item
- Package app
- Don't see it anymore
