### PR TITLE
Validate URL in open repl window handler

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,7 @@ export const workspaceUrlRegex = /^\/@\S+\/\S+/;
 
 export const homePage = "/desktopApp/home";
 export const authPage = "/desktopApp/auth";
+export const desktopAppPrefix = "/desktopApp";
 
 // https://www.electronjs.org/docs/latest/api/app#appispackaged-readonly
 export const isProduction = app.isPackaged;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -1,6 +1,11 @@
 import { BrowserWindow, ipcMain, shell } from "electron";
 import { createWindow } from "./createWindow";
-import { authPage, baseUrl } from "./constants";
+import {
+  authPage,
+  baseUrl,
+  desktopAppPrefix,
+  workspaceUrlRegex,
+} from "./constants";
 import { events } from "./events";
 import store from "./store";
 
@@ -23,8 +28,17 @@ export function setIpcEventListeners(): void {
     store.setLastOpenRepl(null);
   });
 
-  ipcMain.on(events.OPEN_REPL_WINDOW, (_, replSlug) => {
-    const url = `${baseUrl}${replSlug}`;
+  ipcMain.on(events.OPEN_REPL_WINDOW, (_, slug) => {
+    const isSupportedPage =
+      slug.startsWith(desktopAppPrefix) ||
+      workspaceUrlRegex.test(slug) ||
+      slug === "/logout";
+
+    if (!isSupportedPage) {
+      throw new Error("Page not supported");
+    }
+
+    const url = `${baseUrl}${slug}`;
     createWindow({ url });
   });
 


### PR DESCRIPTION
# Why

Similar to https://github.com/replit/desktop/pull/80, we want to validate that the URL is valid when handling this message to prevent arbitrary navigation around the web app.

# What changed

Validate URL in open repl window handler

# Test plan 

`openReplUrl` works as expected but does not allow any non-valid page
