### PR TITLE
Add isSupportedPage helper

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -12,9 +12,9 @@ import {
   workspaceUrlRegex,
   homePage,
   authPage,
-  desktopAppPrefix,
 } from "./constants";
 import { events } from "./events";
+import isSupportedPage from "./isSupportedPage";
 import { isMac } from "./platform";
 import store from "./store";
 
@@ -120,13 +120,9 @@ export function createWindow(props?: WindowProps): BrowserWindow {
     const url = new URL(navigationUrl);
 
     const isReplit = url.origin === baseUrl;
-    const isSupportedPage =
-      url.pathname.startsWith(desktopAppPrefix) ||
-      workspaceUrlRegex.test(url.pathname) ||
-      url.pathname === "/logout";
 
     // Prevent navigation away from Replit or supported pages
-    if (!isReplit || !isSupportedPage) {
+    if (!isReplit || !isSupportedPage(url.pathname)) {
       event.preventDefault();
       shell.openExternal(navigationUrl);
     }

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -1,13 +1,9 @@
 import { BrowserWindow, ipcMain, shell } from "electron";
 import { createWindow } from "./createWindow";
-import {
-  authPage,
-  baseUrl,
-  desktopAppPrefix,
-  workspaceUrlRegex,
-} from "./constants";
+import { authPage, baseUrl } from "./constants";
 import { events } from "./events";
 import store from "./store";
+import isSupportedPage from "./isSupportedPage";
 
 /**
  * Set listeners for IPC, or inter-process communication, events that are
@@ -29,12 +25,7 @@ export function setIpcEventListeners(): void {
   });
 
   ipcMain.on(events.OPEN_REPL_WINDOW, (_, slug) => {
-    const isSupportedPage =
-      slug.startsWith(desktopAppPrefix) ||
-      workspaceUrlRegex.test(slug) ||
-      slug === "/logout";
-
-    if (!isSupportedPage) {
+    if (!isSupportedPage(slug)) {
       throw new Error("Page not supported");
     }
 

--- a/src/isSupportedPage.ts
+++ b/src/isSupportedPage.ts
@@ -1,0 +1,11 @@
+import { desktopAppPrefix, workspaceUrlRegex } from "./constants";
+
+const supportedNonDesktopAppPages = ["logout"];
+
+export default function isSupportedPage(page: string): boolean {
+  return (
+    page.startsWith(desktopAppPrefix) ||
+    workspaceUrlRegex.test(page) ||
+    supportedNonDesktopAppPages.includes(page)
+  );
+}


### PR DESCRIPTION
# Why

We use this in a couple places now and I wanted to make sure this logic gets standardized

# What changed

Add isSupportedPage helper that does what you'd expect

# Test plan 

supported page logic works as expected in the open repl window / did-navigate handlers
