### PR TITLE
Don't restore window bounds if prev dimensions are out of bounds

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -44,12 +44,6 @@ function createStore() {
     getLastOpenRepl(): string | null {
       return store.get(keys.LAST_OPEN_REPL, null) as string | null;
     },
-    setNumDisplays(numDisplays: number) {
-      store.set(keys.NUM_DISPLAYS, numDisplays);
-    },
-    getNumDisplays(): number {
-      return store.get(keys.NUM_DISPLAYS, 1) as number;
-    },
   };
 }
 


### PR DESCRIPTION
# Why

It looks super weird when we restore the window bounds but the number of monitors has changed (esp if you remove an external monitor). Instead, we should just bail since you'll likely want to rearrange the dimensions or position of your window anyways in response to an external monitor being added or removed.

Fixes WS-34

# What changed

- Store number of displays
- Bail on the restore bounds logic if the number of displays is different from the last time you closed the app 

# Test plan 

- Open app with an external monitor
- Move around, resize, then close
- Open again
- See position restored
- Disconnect external monitor
- Open app
- See default position
- Move app around, resize, and close
- Open again
- See position restored
- Connect external monitor
- Open app
- See default position
