### PR TITLE
Don't restore window bounds if prev dimensions are out of bounds

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -44,12 +44,6 @@ function createStore() {
     getLastOpenRepl(): string | null {
       return store.get(keys.LAST_OPEN_REPL, null) as string | null;
     },
-    setNumDisplays(numDisplays: number) {
-      store.set(keys.NUM_DISPLAYS, numDisplays);
-    },
-    getNumDisplays(): number {
-      return store.get(keys.NUM_DISPLAYS, 1) as number;
-    },
   };
 }
 


### PR DESCRIPTION
# Why

Same as https://github.com/replit/desktop/pull/85 but a different heuristic. We don't want to restore the previous dimensions if they don't fit in the current set of displays anymore

# What changed

Don't restore window bounds if prev dimensions are out of bounds

# Test plan 

Same test plan as above PR but with check that app is in bounds instead of there being the same # of displays
