### PR TITLE
Fix spelling of iconUrl in the Squirrel maker config

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -71,7 +71,7 @@ module.exports = {
       name: "@electron-forge/maker-squirrel",
       config: {
         setupIcon: "./assets/logo.ico",
-        iconURL: "https://replit.com/public/images/logo.ico",
+        iconUrl: "https://replit.com/public/images/logo.ico",
         certificateFile: process.env.WINDOWS_CERTIFICATE_FILE,
         certificatePassword: process.env.WINDOWS_CERTIFICATE_PASSWORD,
       },


### PR DESCRIPTION
# Why

This is causing the Electron Icon to appear next to the app when listed in the "Programs and features" and "Installed apps" sections on Windows. Fixes WS-600

I thought I fixed this in https://github.com/replit/desktop/pull/37 but it turns out that I got the spelling wrong 🤦  

Apparently, that's a fairly common issue: https://github.com/electron/forge/issues/2941#issuecomment-1261255135

# What changed

Fix spelling of iconUrl in the Squirrel maker config

# Test plan 

Should see our own icon instead of Electron in those places after the next build
