### PR TITLE
Don't reset last open repl on window close

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -168,10 +168,6 @@ export function createWindow(props?: WindowProps): BrowserWindow {
     store.setWindowBounds(window.getBounds());
   });
 
-  window.on("closed", () => {
-    store.setLastOpenRepl(null);
-  });
-
   window.on("focus", () => {
     const url = window.webContents.getURL();
     setLastOpenRepl(url);


### PR DESCRIPTION
# Why

Realized that we don't want to actually reset the last open repl state here when the window is closed especially now that we handle the focus event: https://github.com/replit/desktop/pull/88

This is because, on Windows and Linux, the most common way to exit the application is to close the window (as opposed to Mac where you might hit Cmd+Q instead which doesn't fire this event) which means the last open repl is never restored in practice.

Instead, the current logic that listens to transition and focus events should be sufficient.

# What changed

Don't reset last open repl on window close

# Test plan 

Should be able to close the last window of the app in Windows and Linux and see the last open repl restored.
