### PR TITLE
Add support for deeplinks to home page

### DIFF
--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -6,6 +6,7 @@ import {
   workspaceUrlRegex,
   semverRegex,
   authPage,
+  homePage,
 } from "./constants";
 import path from "path";
 import { createWindow } from "./createWindow";
@@ -41,6 +42,12 @@ function handleDeeplink(deeplink: string): void {
       break;
     }
 
+    case "home": {
+      handleHome();
+
+      break;
+    }
+
     case "repl": {
       handleRepl(url.pathname);
 
@@ -51,6 +58,22 @@ function handleDeeplink(deeplink: string): void {
       console.error("Unrecognized hostname");
     }
   }
+}
+
+function handleHome() {
+  const homeUrl = `${baseUrl}${homePage}`;
+
+  const focused = BrowserWindow.getFocusedWindow();
+
+  if (focused) {
+    focused.loadURL(homeUrl);
+
+    return;
+  }
+
+  createWindow({
+    url: homeUrl,
+  });
 }
 
 function handleRepl(url: string) {


### PR DESCRIPTION
# Why

Think it would be useful for cases we want to link to the app but not any specific Repl.

# What changed

Add support for deeplinks to the home page via the following format: `replit://home`

# Test plan 

Visit `replit://home` with the app open -> see the home page come up (either in focused window if there is one, or in a new window)
