### PR TITLE
Add support for replit://new deeplink

### DIFF
--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -48,6 +48,12 @@ function handleDeeplink(deeplink: string): void {
       break;
     }
 
+    case "new": {
+      handleNew(url.searchParams.get('language') || 'python3');
+
+      break;
+    }
+
     case "repl": {
       handleRepl(url.pathname);
 
@@ -73,6 +79,14 @@ function handleHome() {
 
   createWindow({
     url: homeUrl,
+  });
+}
+
+function handleNew(language: string) {
+  const url = `${baseUrl}${homePage}?language=${language}`;
+
+  createWindow({
+    url,
   });
 }
 


### PR DESCRIPTION
# Why

Follow on to the web changes introduced here: https://github.com/replit/repl-it-web/pull/35098. This PR introduces a new deeplink endpoint, `replit://new` which optionally accepts a `language` query param which will open a new window with the new Repl modal prefilled to the specified language if provided, or Python if not.

Fixes WS-772

# What changed

Add support for replit://new deeplink

# Test plan 

- Run `pnpm start:local` with corresponding web changes checked out
- Open `replit://new`
- See new window appear with new repl modal open, prefilled with Python
- Open `replit://new?language=nodejs`
- Same as above but prefilled with Node
