### PR TITLE
[WS-689] minimize white flashes

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -175,7 +175,7 @@ export function createWindow(props?: WindowProps): BrowserWindow {
   window.on("leave-full-screen", () => {
     window.webContents.send(events.ON_LEAVE_FULLSCREEN);
   });
-  
+
   // Bypass the browser's cache when initially loading the remote URL
   // in order to ensure that we load the latest web build.
   // See: https://github.com/electron/electron/issues/1360#issuecomment-156506130


### PR DESCRIPTION
# Why

We got feedback that on Windows we can see a white box flash before the app loads.

The reason is that when we create a new window it defaults to being visible, and we set the size and other properties later on. This PR modifies it so new window starts invisible, and we flip it to visible after we go through the initialization process.

In my non-scientific tests on Windows VM this doesn't show a white box flash, but we still get a white window before we start loading the app. As far as I can tell we're doing everything correctly with `backgroundColor` set from the start, and this might be a Windows thing -- it's not only us and the Electron GitHub is full with issues like this one https://github.com/electron/electron/issues/861

Another solution would be to keep the window hidden until we load the URL and go through the first render as described here https://www.electronjs.org/docs/latest/api/browser-window#using-the-ready-to-show-event but in my tests it takes a while and makes the app feel slow to load.

# What changed

Made the window hidden on start, and show after we set up the size etc.

# Test plan 

Open the app on Windows, notice that we don't flash a white box before the Window opens properly.
