### PR TITLE
Add electron-log

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@sentry/electron": "^4.5.0",
+    "electron-log": "5.0.0-beta.25",
     "electron-squirrel-startup": "^1.0.0",
     "electron-store": "^8.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ dependencies:
   '@sentry/electron':
     specifier: ^4.5.0
     version: 4.5.0
+  electron-log:
+    specifier: 5.0.0-beta.25
+    version: 5.0.0-beta.25
   electron-squirrel-startup:
     specifier: ^1.0.0
     version: 1.0.0
@@ -1936,6 +1939,11 @@ packages:
       - supports-color
     dev: true
     optional: true
+
+  /electron-log@5.0.0-beta.25:
+    resolution: {integrity: sha512-ihfT5W3cGx0x8+tTO+51lyxWbu2pXcbFlBcdYRw13Q4PtJh3n38385ZC7gnpfP9Ou6SFgYfyd2qsL2BYRpulXQ==}
+    engines: {electron: '>= 13', node: '>= 14'}
+    dev: false
 
   /electron-packager@17.1.1:
     resolution: {integrity: sha512-r1NDtlajsq7gf2EXgjRfblCVPquvD2yeg+6XGErOKblvxOpDi0iulZLVhgYDP4AEF1P5/HgbX/vwjlkEv7PEIQ==}


### PR DESCRIPTION
# Why

Seems like a much better solution to logging than just using `console.log` and seems to be the most popular in the community. Biggest thing is it writes also writes to a file in addition to the console (which makes debugging in prod much easier and has better formatting out of the box

See package: https://github.com/megahertz/electron-log

# What changed

`pnpm install electron-log@beta`

# Test plan 

Use in follow up PR
