### PR TITLE
Set deeplink listeners before app is ready

### DIFF
--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -13,7 +13,12 @@ import { createWindow } from "./createWindow";
 import { events } from "./events";
 import log from "electron-log/main";
 
-export function registerDeeplinkProtocol(): void {
+export function initializeDeeplinking(): void {
+  registerDeeplinkProtocol();
+  setOpenDeeplinkListeners();
+}
+
+function registerDeeplinkProtocol(): void {
   log.info("Registering deeplink protocol");
 
   if (process.defaultApp && isWindows() && process.argv.length >= 2) {
@@ -159,7 +164,7 @@ function handleAuthComplete(authToken: string) {
   authWindow.webContents.send(events.AUTH_TOKEN_RECEIVED, authToken);
 }
 
-export function setOpenDeeplinkListeners(): void {
+function setOpenDeeplinkListeners(): void {
   log.info("Setting deeplink listeners");
 
   // Windows and Linux fire a different event when deeplinks are opened

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { isMac } from "./platform";
 import { initSentry } from "./sentry";
 import { createApplicationMenu, createDockMenu } from "./createMenu";
 import checkForUpdates from "./checkForUpdates";
-import { registerDeeplinkProtocol, setOpenDeeplinkListeners } from "./deeplink";
+import { initializeDeeplinking } from "./deeplink";
 import { setIpcEventListeners } from "./ipc";
 import store from "./store";
 import log from "electron-log/main";
@@ -30,8 +30,7 @@ if (require("electron-squirrel-startup")) {
 
 initSentry();
 app.setName(appName);
-registerDeeplinkProtocol();
-setOpenDeeplinkListeners();
+initializeDeeplinking();
 setIpcEventListeners();
 
 const instanceLock = app.requestSingleInstanceLock();


### PR DESCRIPTION
# Why

Turns out we've been missing deeplink events that cause the app to open (e.g. if you open a deeplink but app is not yet running). 

From [the docs](https://www.electronjs.org/docs/latest/api/app#event-open-url-macos):

> As with the open-file event, be sure to register a listener for the open-url event early in your application startup to detect if the the application being is being opened to handle a URL. If you register the listener in response to a ready event, you'll miss URLs that trigger the launch of your application.

Fixes WS-807

# What changed

Set deeplink listeners before app is ready per the docs above

# Test plan 

Deeplinks that open the app should work (this doesn't work in dev so will have to wait until the next release to properly test)
