### PR TITLE
Keep lastOpenRepl in memory

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -44,6 +44,11 @@ function createStore() {
     getLastOpenRepl(): string | null {
       return store.get(keys.LAST_OPEN_REPL, null) as string | null;
     },
+    onLastOpenReplChange(
+      listener: (lastOpenRepl: string | null) => void
+    ): () => void {
+      return store.onDidChange(keys.LAST_OPEN_REPL, listener);
+    },
   };
 }
 


### PR DESCRIPTION
# Why

Wanted to optimize this logic a bit. We shouldn't have to read from the store every time the window is focused or the hash changes in the WS for example. Instead, we can keep the `lastOpenRepl` state in memory as a variable and subscribe to the changes to prevent reading from / writing to the store more than we need to.

Fixes WS-805

# What changed

Keep lastOpenRepl in memory

# Test plan 

lastOpenRepl logic still works as expected
