### PR TITLE
Update default URL to home page instead of authpage

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -13,7 +13,6 @@ import {
   preloadScript as preload,
   workspaceUrlRegex,
   homePage,
-  authPage,
 } from "./constants";
 import log from "electron-log/main";
 import { events } from "./events";
@@ -25,7 +24,7 @@ interface WindowProps {
   url?: string | null;
 }
 
-const defaultUrl = `${baseUrl}${authPage}`;
+const defaultUrl = `${baseUrl}${homePage}`;
 
 function createURL(url?: string | null) {
   if (url) {


### PR DESCRIPTION
# Why

Both redirect to the appropriate place in the case where you're authed or not but the home page is the common case (since you're usually logged in not logged out)

# What changed

Update default URL to home page instead of auth page

# Test plan 

Home page is opened if logged in, auth page still opens when you're unauthed (our server handles both cases)
