### PR TITLE
Make createWindow synchronous + grab first window on deeplink

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -85,7 +85,7 @@ async function getLastSeenBackgroundColor(
   );
 }
 
-async function updateStoreWithFocusedWindowValues() {
+function updateStoreWithFocusedWindowValues() {
   const windows = BrowserWindow.getAllWindows();
 
   // No existing windows open so there's nothing to update
@@ -96,15 +96,15 @@ async function updateStoreWithFocusedWindowValues() {
   // Grab the focused window or the first we see if there isn't one
   const window = BrowserWindow.getFocusedWindow() || windows[0];
 
-  const backgroundColor = await getLastSeenBackgroundColor(window);
-  store.setLastSeenBackgroundColor(backgroundColor);
   store.setWindowBounds(window.getBounds());
+
+  getLastSeenBackgroundColor(window).then((backgroundColor) => {
+    store.setLastSeenBackgroundColor(backgroundColor);
+  });
 }
 
-export async function createWindow(
-  props?: WindowProps
-): Promise<BrowserWindow> {
-  await updateStoreWithFocusedWindowValues();
+export function createWindow(props?: WindowProps): BrowserWindow {
+  updateStoreWithFocusedWindowValues();
   const backgroundColor = store.getLastSeenBackgroundColor();
   const url = createURL(props?.url);
   let lastOpenRepl = store.getLastOpenRepl();

--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -80,13 +80,23 @@ async function handleDeeplink(deeplink: string): Promise<void> {
   }
 }
 
+function getFocusedOrFirstWindow(): BrowserWindow | null {
+  const windows = BrowserWindow.getAllWindows();
+
+  if (windows.length === 0) {
+    return null;
+  }
+
+  return BrowserWindow.getFocusedWindow() || windows[0];
+}
+
 function handleHome() {
   const homeUrl = `${baseUrl}${homePage}`;
 
-  const focused = BrowserWindow.getFocusedWindow();
+  const window = getFocusedOrFirstWindow();
 
-  if (focused) {
-    focused.loadURL(homeUrl);
+  if (window) {
+    window.loadURL(homeUrl);
 
     return;
   }
@@ -111,10 +121,10 @@ function handleRepl(url: string) {
     return;
   }
 
-  const focused = BrowserWindow.getFocusedWindow();
+  const window = getFocusedOrFirstWindow();
 
-  if (focused) {
-    focused.loadURL(`${baseUrl}${url}`);
+  if (window) {
+    window.loadURL(`${baseUrl}${url}`);
 
     return;
   }


### PR DESCRIPTION
# Why

- `createWindow` doesn't need to be async (we don't need to block on setting the right bg color)
- We want the deeplink logic to match the behavior we use for grabbing the "last" window in the `createWindow` function: either the focused window, if one exists, or the first window we find if there are any open.

Main motivation is to prevent a redundant window from opening up when the app is opened via Deeplink (see [Linear](https://linear.app/replit/issue/WS-827/extra-window-opening-when-responding-to-deeplink-that-opens-app)). e.g. if you open a `replit://home` link which launches the app you should see only one window with the home screen pop up not a home screen window and another window with your last Repl. Not sure if this fixes it but it's a good start to avoid race conditions between the onReady logic in main.ts and handling the first deeplink.

# What changed

Make createWindow synchronous + grab 1st window on deeplink like we do when creating window.

# Test plan 

Deeplinks / creating windows should work as expected. The problem designed above is potentially fixed once packaged/released
