### PR TITLE
Increase min width/height of windows to 720x480

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -139,8 +139,8 @@ export function createWindow(props?: WindowProps): BrowserWindow {
     },
     title,
     icon,
-    minWidth: 500,
-    minHeight: 420,
+    minWidth: 720,
+    minHeight: 480,
     backgroundColor,
     autoHideMenuBar: true, // Window & Linux only, hides the menubar unless `Alt` is held
     show: false, // We're starting with the window hidden, as we are still setting it up using imperative methods below


### PR DESCRIPTION
# Why

Aman pointed out this was too small and I agree, esp with the recent changes to the header (density + resource monitor experiment)

Fixes https://linear.app/replit/issue/WS-843/increase-min-widthheight-in-the-desktop-app

# What changed

Min width/height: 500x420 -> 720x480

### Before

<img width="997" alt="Screenshot 2023-08-21 at 2 12 19 PM" src="https://github.com/replit/desktop/assets/24947334/9edb29c0-c360-4702-9784-2812eaa4c8e4">

### After

<img width="1430" alt="Screenshot 2023-08-21 at 2 17 33 PM" src="https://github.com/replit/desktop/assets/24947334/fb028807-c2ab-4273-a159-09a75729a05a">


# Test plan 

- Open app
- Make smol
- Look
