### PR TITLE
Add docs about deeplinking to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We're following a set of principles inspired by protobuf versioning:
 
 ## Deeplinking
 
-The app supports deeplinks with the `replit://` protocol which can be used to open specific pages or flows directly, launching the app if it's not already running.
+The app supports deeplinks with the `replit` protocol which can be used to open specific pages or flows directly, launching the app if it's not already running.
 
 The following deeplinks are currently supported:
 - `replit://home`: Opens the desktop app home page in the focused window (or a new window if none are open).


### PR DESCRIPTION
# Why

We want to document the deeplinking behavior so that others who develop the app and web integrations that link to the app know how it works.

Fixes WS-826

# What changed

Add docs about deeplinking to README

# Test plan 

Read README
