### PR TITLE
Use different store in dev and in prod

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1,45 +1,51 @@
 import { Rectangle, screen } from 'electron';
 import Store from 'electron-store';
+import { isProduction, baseUrl } from './constants';
 
-const keys = {
-  LAST_SEEN_BACKGROUND_COLOR: 'LAST_SEEN_BACKGROUND_COLOR',
-  LAST_SEEN_FOREGROUND_COLOR: 'LAST_SEEN_FOREGROUND_COLOR',
-  LAST_OPEN_REPL: 'LAST_OPEN_REPL',
-  WINDOW_BOUNDS: 'WINDOW_BOUNDS',
-  NUM_DISPLAYS: 'NUM_DISPLAYS',
-};
+enum Key {
+  LAST_SEEN_BACKGROUND_COLOR = 'LAST_SEEN_BACKGROUND_COLOR',
+  LAST_SEEN_FOREGROUND_COLOR = 'LAST_SEEN_FOREGROUND_COLOR',
+  LAST_OPEN_REPL = 'LAST_OPEN_REPL',
+  WINDOW_BOUNDS = 'WINDOW_BOUNDS',
+  NUM_DISPLAYS = 'NUM_DISPLAYS',
+}
 
 // Default values for var(--background-root) and var(--foreground-default) in dark mode.
 const defaultBgColor = '#0E1525';
 const defaultFgColor = '#F5F9FC';
 
+// Different store in the different dev modes and in production
+const name = isProduction ? 'config' : `config-dev-${baseUrl}`;
+
 function createStore() {
-  const store = new Store();
+  const store = new Store({
+    name,
+  });
 
   return {
     setLastSeenBackgroundColor(color: string) {
-      store.set(keys.LAST_SEEN_BACKGROUND_COLOR, color);
+      store.set(Key.LAST_SEEN_BACKGROUND_COLOR, color);
     },
     getLastSeenBackgroundColor(): string {
       return store.get(
-        keys.LAST_SEEN_BACKGROUND_COLOR,
+        Key.LAST_SEEN_BACKGROUND_COLOR,
         defaultBgColor,
       ) as string;
     },
     setLastSeenForegroundColor(color: string) {
-      store.set(keys.LAST_SEEN_FOREGROUND_COLOR, color);
+      store.set(Key.LAST_SEEN_FOREGROUND_COLOR, color);
     },
     getLastSeenForegroundColor(): string {
       return store.get(
-        keys.LAST_SEEN_FOREGROUND_COLOR,
+        Key.LAST_SEEN_FOREGROUND_COLOR,
         defaultFgColor,
       ) as string;
     },
     clearWindowBounds() {
-      store.delete(keys.WINDOW_BOUNDS);
+      store.delete(Key.WINDOW_BOUNDS);
     },
     setWindowBounds(bounds: Rectangle) {
-      store.set(keys.WINDOW_BOUNDS, bounds);
+      store.set(Key.WINDOW_BOUNDS, bounds);
     },
     getWindowBounds(): Rectangle {
       // We're assuming that the active screen is the one with the mouse cursor.
@@ -47,18 +53,18 @@ function createStore() {
       const mousePosition = screen.getCursorScreenPoint();
       const mouseScreen = screen.getDisplayNearestPoint(mousePosition);
 
-      return store.get(keys.WINDOW_BOUNDS, mouseScreen.workArea) as Rectangle;
+      return store.get(Key.WINDOW_BOUNDS, mouseScreen.workArea) as Rectangle;
     },
     setLastOpenRepl(path: string | null) {
-      store.set(keys.LAST_OPEN_REPL, path);
+      store.set(Key.LAST_OPEN_REPL, path);
     },
     getLastOpenRepl(): string | null {
-      return store.get(keys.LAST_OPEN_REPL, null) as string | null;
+      return store.get(Key.LAST_OPEN_REPL, null) as string | null;
     },
     onLastOpenReplChange(
       listener: (lastOpenRepl: string | null) => void,
     ): () => void {
-      return store.onDidChange(keys.LAST_OPEN_REPL, listener);
+      return store.onDidChange(Key.LAST_OPEN_REPL, listener);
     },
   };
 }


### PR DESCRIPTION
# Why

I find it annoying developing the app that we use the same store for dev (incl in local and staging modes) as well as in prod. This leads to issues like the app trying to open a repl that doesn't exist (e.g. when switching from dev to prod and vice versa). See relevant docs: https://github.com/sindresorhus/electron-store#name

# What changed

Use different store in dev (and the diff dev modes like `start:local` and `start:staging`) and in prod. Also switching to using enum here since that's a bit more fitting

# Test plan 

Open each one, resize window in each, should see window pos/bounds be persisted only for that version (e.g. local, staging, prod).
