### PR TITLE
Remove reload menu items from View menu in prod

### DIFF
--- a/src/createMenu.ts
+++ b/src/createMenu.ts
@@ -92,16 +92,18 @@ export function createApplicationMenu(): Menu {
     ],
   });
 
+  const devOnlyMenuItems = [
+    { role: 'reload' },
+    { role: 'forceReload' },
+    { role: 'toggleDevTools' },
+    { type: 'separator' },
+  ];
+
   // View Menu
   template.push({
     label: 'View',
     submenu: [
-      { role: 'reload' },
-      { role: 'forceReload' },
-      // Don't expose dev tools in production
-      ...(!isProduction ? [{ role: 'toggleDevTools' }] : []),
-      { type: 'separator' },
-      { type: 'separator' },
+      ...(!isProduction ? devOnlyMenuItems : []),
       { role: 'togglefullscreen' },
     ],
   });


### PR DESCRIPTION
# Why

Being able to "Refresh" a desktop app feels unnatural in some ways and makes it feel more like a web / electron app. It would also be nice to free up the Ctrl/Cmd + R keybinding for other use cases like running which would be useful for those coming from IDEs like xcode which has that same binding. See [Slack thread](https://replit.slack.com/archives/C0509G0FJNL/p1693193588958109).

Still keeping it around in "dev" (e.g. unpackaged) bc it would be useful to refresh the app in certain cases when developing or in a bad state.

# What changed

Remove reload and force reload menu items from the View menu in prod

# Test plan 

Should not see reload/force reload after the next release. Ctrl/Cmd + R should not do anything and should be an available user-space keybinding.
