### PR TITLE
feat: enable webview tag support

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -147,6 +147,7 @@ export function createWindow(props?: WindowProps): BrowserWindow {
         `--platform=${process.platform}`,
       ],
       scrollBounce: true, // MacOS only
+      webviewTag: true, // Enables support for devtools access on frames
     },
     title,
     icon,


### PR DESCRIPTION
# Why

<!-- Describe what prompted you to make this change, link relevant resources: Asana tasks, Canny report, Slack discussions, etc -->

We spoke about developer tools in the weekly team sync and one thing that was mentioned was that removing our devtools wrapper would make it more awkward to develop on Desktop since we didn't give users access to the chrome devtools there. I took some time to look into this and found that we can enable devtools for the specific webview that users will need to inspect.

# What changed

<!-- Describe what changed to a level of detail that someone with no context with your PR could be able to review it (including screenshots if relevant) -->

The [`webviewTag`](https://www.electronjs.org/docs/latest/api/webview-tag) feature has been enabled in the main browser window. This acts similarly to an `iframe`, but with added features supported by Electron. We don't enable any of these features for this use case so user applications should remain sandboxed like normal frames. What we do make use of is Electron's ability to open developer tools for these specific webviews since they are now managed differently internally. Because of this we can call `webview.openDevTools()` to give the user a real Chrome Developer Tools window that is scoped to just their webview.

The functional changes are over in repl-it-web and will rely on rendering a `<webview>` tag and calling the appropriate methods to open and close the developer tools.

# Test plan 

<!-- Describe what you did to test this change to a level of detail that allows your reviewer to test it -->

The functionality is in repl-it-web and is gated behind the flag [`flag-desktop-integrated-devtools`](https://app.launchdarkly.com/default/dev/features/flag-desktop-integrated-devtools/targeting). Adding yourself to that flag once both this pull request and the repl-it-web pull request are in will allow you to test that the native chrome devtools are used instead of our wrapper when in the desktop application.

The _only_ functionality that should change is within the desktop app when this flag is toggled on. Web and mobile will continue working just like before with the devtools wrapper.
