### PR TITLE
Remove scrollBounce option in browser window

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -146,7 +146,6 @@ export function createWindow(props?: WindowProps): BrowserWindow {
         `--app-version=${app.getVersion()}`,
         `--platform=${process.platform}`,
       ],
-      scrollBounce: true, // MacOS only
       webviewTag: true, // Enables support for devtools access on frames
     },
     title,


### PR DESCRIPTION
# Why

See discussion here: https://github.com/replit/repl-it-web/pull/35839.

Looks a bit weird in the context of our app, esp on the home page where we'd rather have things be static.

# What changed

Remove scrollBounce option in browser window (only affects MacOS)

# Test plan 

- Open home page / WS in app
- Scroll (outside of a scroll container)
- Should not see bounce
