### PR TITLE
Fix last open repl logic on focus

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -210,7 +210,7 @@ export function createWindow(props?: WindowProps): BrowserWindow {
   });
 
   window.on('focus', () => {
-    setLastOpenRepl(url, lastOpenRepl);
+    setLastOpenRepl(window.webContents.getURL(), lastOpenRepl);
   });
 
   window.on('enter-full-screen', () => {


### PR DESCRIPTION
# Why

The last open repl logic was finicky and not working correctly. Turns out it's because we were using the original URL of the opened window rather than the current one when resetting the state in response to the focus event.

Fixes WS-962

# What changed

Fix last open repl logic on focus by using the current, not initial, URL

# Test plan 

- Open 2 windows in the app
- Navigate around / focus
- Test last open URL state changes accordingly (via logs)
- Close and reopen - should see the right repl open up
