### PR TITLE
Remove "close" menu item

### DIFF
--- a/src/createMenu.ts
+++ b/src/createMenu.ts
@@ -6,7 +6,7 @@ import {
   MenuItem,
   MenuItemConstructorOptions,
 } from 'electron';
-import { isProduction, baseUrl } from './constants';
+import { baseUrl, isProduction } from './constants';
 import { createWindow } from './createWindow';
 import { isMac } from './platform';
 


### PR DESCRIPTION
# Why

Perhaps this is due to the recent Electron upgrade (although I can't find anything in the Changelog about this) but hitting Cmd+W on Mac now seems to close the window in the app. This is undesirable because we want to leave this keyboard shortcut available for users to set and also want to prevent that shortcut from closing the window as it does not in most other apps / IDEs. Turns out it's because we add a menu item with the "close" role which sets this keyboard shortcut. (see relevant [SO post](https://stackoverflow.com/questions/60350520/electron-browser-window-prevent-controlw-closing-window) and [GH issue](https://github.com/electron/electron/issues/5951))

Additionally, I was thinking we should remove the "Open Repl URL from Clipboard" menu item. It's too niche to be useful (since you have to have a Repl URL copied in your clipboard to begin with) and is hard to find / not intuitive anyways.

Fixes WS-965

# What changed

Remove "Close" and "Open Repl URL from clipboard" menu items

# Test plan 

- Open "File" menu - should not see the above anymore
- Cmd+W doesn't close the window anymore
