### PR TITLE
Enable experimental-web-platform-features flag

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,10 @@ if (!instanceLock) {
 
 Menu.setApplicationMenu(createApplicationMenu());
 
+// We add this flag to support the FileSystem API which is used for "download to png" among other things.
+// See https://github.com/electron/electron/issues/28422
+app.commandLine.appendSwitch('enable-experimental-web-platform-features');
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.


### PR DESCRIPTION
# Why

In debugging the attached Linear task, I discovered that the filesystem/files web APIs do not work correctly in Electron unless this flag is enabled which means things like downloading pngs does not work as expected. See relevant open issue: https://github.com/electron/electron/issues/28422

Adding this flag fixes the issue and likely enables other Chromium features that we / deps we rely on might use. While the [docs](https://www.electronjs.org/docs/latest/tutorial/security#9-do-not-enable-experimental-features) warn against using this feature, I don't see a convincing reason if it works for us, fixes issues like this, and especially given that we control which content is loaded into the browser window.

Fixes WS-1076

# What changed

Enable experimental-web-platform-features flag for the app

# Test plan 

Download as png works as expected in draw files in the app per the repro steps in the attached Linear task
