### PR TITLE
Be resilient to invalid URLs in deeplinks

### DIFF
--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -36,11 +36,18 @@ function registerDeeplinkProtocol(): void {
 async function handleDeeplink(deeplink: string): Promise<void> {
   log.info(`Arrived from deeplink: ${deeplink}`);
 
-  const url = new URL(deeplink);
+  let url;
+  try {
+    url = new URL(deeplink);
 
-  // Remove trailing ":"
-  if (url.protocol.slice(0, -1) !== protocol) {
-    throw new Error('Invalid protocol');
+    // Remove trailing ":"
+    if (url.protocol.slice(0, -1) !== protocol) {
+      throw new Error('Invalid protocol');
+    }
+  } catch {
+    log.warn('Invalid URL for deeplink');
+
+    return;
   }
 
   // We set the listeners before the app is ready to make sure we don't miss any events


### PR DESCRIPTION
# Why

It appears the `second-instance` event (used by deeplinks) can fire in other cases too, at least on Windows. This is resulting in one of our highest errors in [Sentry](https://replit-kq.sentry.io/issues/4464011475/?project=4505167464693760&query=is%3Aunresolved&referrer=issue-stream&stream_index=2) since we assume they are all valid URLs which is evidently not the case.

# What changed

Be resilient to invalid URLs in deeplinks and log instead of throwing.

# Test plan 

Should see the Sentry error go to 0 after this
