### PR TITLE
Manually invoke Sentry crash reporter

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -3,10 +3,15 @@ import { isProduction } from './constants';
 import log from 'electron-log/main';
 import store from './store';
 import type { User } from './types';
+import { crashReporter } from 'electron';
 
 // DSN for "desktop" project in Sentry
 const dsn =
   'https://d88a656213ca4c1892091cc955fd7783@o1151714.ingest.sentry.io/4505167464693760';
+
+// See https://docs.sentry.io/platforms/javascript/guides/electron/#electron-native-manual
+const submitURL =
+  'https://o1151714.ingest.sentry.io/api/4505167464693760/minidump/?sentry_key=d88a656213ca4c1892091cc955fd7783';
 
 export function initSentry(): void {
   if (!isProduction) {
@@ -18,8 +23,11 @@ export function initSentry(): void {
   Sentry.init({
     dsn,
   });
-
   setSentryUser(store.getUser());
+
+  crashReporter.start({
+    submitURL,
+  });
 }
 
 export function setSentryUser(user: User | null) {


### PR DESCRIPTION
# Why

I thought that Sentry automatically captures and reports native crashes but I haven't actually been seeing them appear in the dashboard and this lack of visibility is making it harder to debug crashes when we get reports of them from users or internally.

Their [docs](https://docs.sentry.io/platforms/javascript/guides/electron/) are pretty confusing about whether or not you need to manually configure crash reporting via the Electron `crashReporter` module but I think it's worth a try to be safe.

# What changed

Manually invoke Sentry crash reporter via [these](https://docs.sentry.io/platforms/javascript/guides/electron/#electron-native-manual) instructions. See also relevant Electron [docs](https://www.electronjs.org/docs/latest/api/crash-reporter).

# Test plan 

Should see native crashes (particularly from macOS) start appearing in Sentry.
