### PR TITLE
Upgrade Electron to 26.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@typescript-eslint/parser": "^4.33.0",
     "cpy": "^9.0.1",
     "cross-env": "^7.0.3",
-    "electron": "^26.2.1",
+    "electron": "^26.3.0",
     "electron-winstaller": "^5.1.0",
     "esbuild": "^0.18.6",
     "eslint": "^8.47.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ devDependencies:
     specifier: ^7.0.3
     version: 7.0.3
   electron:
-    specifier: ^26.2.1
-    version: 26.2.1
+    specifier: ^26.3.0
+    version: 26.3.0
   electron-winstaller:
     specifier: ^5.1.0
     version: 5.1.0
@@ -2148,8 +2148,8 @@ packages:
       - supports-color
     dev: true
 
-  /electron@26.2.1:
-    resolution: {integrity: sha512-SNT24Cf/wRvfcFZQoERXjzswUlg5ouqhIuA2t9x2L7VdTn+2Jbs0QXRtOfzcnOV/raVMz3e8ICyaU2GGeciKLg==}
+  /electron@26.3.0:
+    resolution: {integrity: sha512-7ZpvSHu+jmqialSvywTZnOQZZGLqlyj+yV5HGDrEzFnMiFaXBRpbByHgoUhaExJ/8t/0xKQjKlMRAY65w+zNZQ==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true


### PR DESCRIPTION
# Why

A high sev dependabot alert just got opened that affects our version of Electron (`26.2.1`): https://github.com/advisories/GHSA-qqvq-6xgj-jw8g

Updating to the latest version (`26.3.0`) will fix this.

# What changed

Upgrade Electron to 26.3.0. See [release notes](https://github.com/electron/electron/releases) (including the [release](https://github.com/electron/electron/releases/tag/v26.2.4) with the fix).

# Test plan 

App starts/works as expected. Dep alert is resolved.
