### PR TITLE
Explicitly pass in arch to make when building, mark GH workflow files as config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,4 +75,4 @@ jobs:
       - name: Install
         run: pnpm install
       - name: Make
-        run: pnpm run make
+        run: pnpm run make --arch=${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
               - package.json
               - tsconfig.json
               - forge.config.js
+              - .github/workflow/**
 
   make:
     name: Make (${{ matrix.os }} - ${{ matrix.arch }})


### PR DESCRIPTION
# Why

We pass in the arch in the [publish workflow](https://github.com/replit/desktop/blob/e303e5842b5d3525c723026deeaf2983a157f3a4/.github/workflows/publish.yml#L50) so we should do it here for consistency.

In addition, we should rerun the build step anytime any of the workflow files change since those can affect the build.

# What changed

Explicitly pass in arch to make in the build workflow. Rerun build step when anything under `.github/workflows` changes

# Test plan 

Build steps should run and pass
