### PR TITLE
Don't run build workflow for tagged commits on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags-ignore:
+      - v*
   pull_request:
     branches:
       - main


### PR DESCRIPTION
# Why

We don't need to run this job for tagged commits to main (i.e. releases) since we already run the publish workflow which basically does a superset of the same thing (minus lint) which makes this redundant.

# What changed

Don't run build workflow for tagged commits on main

# Test plan 

Next time we publish we should _only_ see the publish workflow run instead of both publish and build
