### PR TITLE
Add support for devtools via env var

### DIFF
--- a/src/createMenu.ts
+++ b/src/createMenu.ts
@@ -105,7 +105,7 @@ export function createApplicationMenu(): Menu {
     label: 'View',
     submenu: [
       ...(!isProduction ? devOnlyMenuItems : []),
-      ...(allowDevtools ? { role: 'toggleDevTools' } : []),
+      ...(allowDevtools ? [{ role: 'toggleDevTools' }] : []),
       { role: 'togglefullscreen' },
     ],
   });


### PR DESCRIPTION
# Why
I need to debug in prod


# What changed

Enable devtools menu while in production via env var

# Test plan 

- Add `ENABLE_DEVTOOLS=1` in shell
- Start Replit
- See toggle devtools under view menu