### PR TITLE
Upgrade Electron to 26.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@typescript-eslint/parser": "^4.33.0",
     "cpy": "^9.0.1",
     "cross-env": "^7.0.3",
-    "electron": "^26.3.0",
+    "electron": "^26.4.1",
     "electron-winstaller": "^5.1.0",
     "esbuild": "^0.18.6",
     "eslint": "^8.47.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ devDependencies:
     specifier: ^7.0.3
     version: 7.0.3
   electron:
-    specifier: ^26.3.0
-    version: 26.3.0
+    specifier: ^26.4.1
+    version: 26.4.1
   electron-winstaller:
     specifier: ^5.1.0
     version: 5.1.0
@@ -2148,8 +2148,8 @@ packages:
       - supports-color
     dev: true
 
-  /electron@26.3.0:
-    resolution: {integrity: sha512-7ZpvSHu+jmqialSvywTZnOQZZGLqlyj+yV5HGDrEzFnMiFaXBRpbByHgoUhaExJ/8t/0xKQjKlMRAY65w+zNZQ==}
+  /electron@26.4.1:
+    resolution: {integrity: sha512-G6Huzx2xP+Atknj68EsD/TzjpFSsl7nbfBcDqKf1p9DaPMIB5HRqpts3s/sd5daWinNrWInREEw2A4EavP59qw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true


### PR DESCRIPTION
# Why

This release contains the fix (https://github.com/electron/electron/pull/40179) for an issue upstream that I submitted a couple weeks ago: https://github.com/electron/electron/issues/39885

Fixes WS-1003

# What changed

Upgrade Electron to 26.4.1

# Test plan 

Should see the above bug no longer repros locally
