### PR TITLE
Cleanup logs in dev

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { app, Menu, BrowserWindow } from 'electron';
 import { createWindow } from './createWindow';
-import { appName, macAppIcon } from './constants';
+import { appName, isProduction, macAppIcon } from './constants';
 import { isMac } from './platform';
 import { initSentry } from './sentry';
 import { createApplicationMenu, createDockMenu } from './createMenu';
@@ -14,9 +14,12 @@ import log from 'electron-log/main';
 log.initialize({ preload: true });
 log.errorHandler.startCatching();
 
-log.info(`Launching app version: ${app.getVersion()}`);
-log.info(`Platform: ${process.platform}`);
-log.info(`Arch: ${process.arch}`);
+const version = isProduction
+  ? app.getVersion()
+  : `${app.getVersion()} (development)`;
+
+log.info(`Launching app version: ${version}`);
+log.info(`Platform: ${process.platform} (${process.arch})`);
 log.info(`Args: ${process.argv}`);
 
 // Handles Squirrel (https://github.com/Squirrel/Squirrel.Windows) events on Windows.


### PR DESCRIPTION
# Why

I wanna add (development) to the outputted version in the logs in dev to make it more obvious that the app is not packaged and therefore has certain implications (like not supporting auto-updating). Also, the arch is arguably part of the "platform" so think we can condense this log into one.

# What changed

Just cleaning up some logs

# Test plan 

- `pnpm start`
- Should see updated logs
