### PR TITLE
Update Node/pnpm engines to match repl-it-web

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "author": "Replit",
   "main": "./dist/main.js",
   "engines": {
-    "pnpm": "8.5.1"
+    "node": "^18.18.2",
+    "pnpm": ">=8.5.1"
   },
   "prettier": {
     "trailingComma": "all",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "author": "Replit",
   "main": "./dist/main.js",
   "engines": {
-    "node": "^18.18.2",
     "pnpm": ">=8.5.1"
   },
   "prettier": {


### PR DESCRIPTION
# Why

Matches repl-it-web and more flexibility in which pnpm version you can use (I'm on the latest now)

# What changed

Update Node/pnpm engines to match repl-it-web

# Test plan 

- Use latest pnpm
- No errors on `pnpm start`
