### PR TITLE
Upgrade Electron to 28.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@typescript-eslint/parser": "^4.33.0",
     "cpy": "^9.0.1",
     "cross-env": "^7.0.3",
-    "electron": "^26.4.1",
+    "electron": "^28.1.0",
     "electron-winstaller": "^5.1.0",
     "esbuild": "^0.18.6",
     "eslint": "^8.47.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,8 +56,8 @@ devDependencies:
     specifier: ^7.0.3
     version: 7.0.3
   electron:
-    specifier: ^26.4.1
-    version: 26.6.1
+    specifier: ^28.1.0
+    version: 28.1.0
   electron-winstaller:
     specifier: ^5.1.0
     version: 5.2.1
@@ -2189,8 +2189,8 @@ packages:
       - supports-color
     dev: true
 
-  /electron@26.6.1:
-    resolution: {integrity: sha512-4Vz9u0Jt/khPa/en2l8Jv6SWEfsK/ieWYtchl5j0clbNSjdeTucnEFOhz9B9WwsAmfQjxBnpuMZpmdBuyxq+wg==}
+  /electron@28.1.0:
+    resolution: {integrity: sha512-82Y7o4PSWPn1o/aVwYPsgmBw6Gyf2lVHpaBu3Ef8LrLWXxytg7ZRZr/RtDqEMOzQp3+mcuy3huH84MyjdmP50Q==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true
@@ -2227,6 +2227,7 @@ packages:
 
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+    requiresBuild: true
     dependencies:
       once: 1.4.0
     dev: true


### PR DESCRIPTION
# Why

We're ~5 weeks behind which apparently is 2 major versions. Anyways, the immediate impetus for this upgrade is to see if this fixes the crashes we've been seeing that users are reporting frequently. Judging by the responses in this issue it seems upgrading from v26 to v28 has helped at least a few people: https://github.com/electron/electron/issues/37531#issuecomment-1860408750

As with any version bump, we should see some misc bug fixes/improvements.

# What changed

Upgrade Electron to 28.1.0

# Test plan 

Should see fewer crashes in Sentry. Otherwise, the desktop app should largely work and function the same.
