### PR TITLE
Validate external URLs are http(s) before opening externally

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -170,6 +170,22 @@ export function createWindow(props?: WindowProps): BrowserWindow {
   // Prevent any URLs opened via a target="_blank" anchor tag or programmatically using `window.open` from
   // opening in an Electron window and open in the user's external browser instead.
   window.webContents.setWindowOpenHandler((details) => {
+    try {
+      const u = new URL(details.url);
+
+      // Don't open URLs with protocols other than http / https externally since they may open other apps.
+      if (u.protocol !== 'https:' && u.protocol !== 'http:') {
+        return {
+          action: 'deny',
+        };
+      }
+    } catch {
+      // The URL constructor throws a TypeError for malformed URLs so we can just ignore here if one is opened.
+      return {
+        action: 'deny',
+      };
+    }
+
     shell.openExternal(details.url);
 
     return {
@@ -189,6 +205,12 @@ export function createWindow(props?: WindowProps): BrowserWindow {
     // Prevent navigation away from Replit or supported pages
     if (!isReplit || !isSupportedPage(u.pathname)) {
       event.preventDefault();
+
+      // Don't open URLs with protocols other than http / https externally since they may open other apps.
+      if (u.protocol !== 'https:' && u.protocol !== 'http:') {
+        return;
+      }
+
       shell.openExternal(navigationUrl);
     }
   });


### PR DESCRIPTION
# Why

See [H1 Report](https://hackerone.com/reports/2355382). We should validate that any externally opened URLs are http/https since otherwise a malicious or malformed URL could open another app on the users machine with that protocol registered which may cause unwanted code to be executed.

Fixes WS-2623

# What changed

Validate external URLs are http(s) before opening externally

# Test plan 

- Try to open a non http url from the devtools in the app
- Fails to open
- Open an https URL from the devtools or click a link to e.g. our docs in the app
- Still opens
