### PR TITLE
Add vscode:// and replit:// to external protocol allowlist

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -122,6 +122,10 @@ function getPlatformSpecificStyling({
   return {};
 }
 
+const EXTERNAL_PROTOCOLS_ALLOW_LIST = ['http', 'https', 'replit', 'vscode'].map(
+  (p) => `${p}:`,
+);
+
 export function createWindow(props?: WindowProps): BrowserWindow {
   updateStoreWithFocusedWindowValues();
   const backgroundColor = store.getLastSeenBackgroundColor();
@@ -206,8 +210,9 @@ export function createWindow(props?: WindowProps): BrowserWindow {
     if (!isReplit || !isSupportedPage(u.pathname)) {
       event.preventDefault();
 
-      // Don't open URLs with protocols other than http / https externally since they may open other apps.
-      if (u.protocol !== 'https:' && u.protocol !== 'http:') {
+      // Don't open URLs with protocols other than those we explicitly allow otherwise to prevent users
+      // from opening external apps and running untrusted code that could compromise their machines.
+      if (!EXTERNAL_PROTOCOLS_ALLOW_LIST.includes(u.protocol)) {
         return;
       }
 


### PR DESCRIPTION
# Why

We want `replit://` links to work in the app for obvious reasons (e.g. performing actions or opening new windows via links) and also want to support `vscode://` URLs explicitly so that the new "Open in VS Code" button and relevant SSH functionality works as expected (see attached Linear task).

Fixes WS-3018

# What changed

Add vscode:// and replit:// to external protocol allowlist

# Test plan 

- Open `replit://` and/or `vscode://` links from the app -> works
- New "Open in VS Code" button works as expected in the desktop app
- Opening http(s) external links still works as expected in the app
