### PR TITLE
Update window open handler to accept new allowlisted protocols

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -177,8 +177,9 @@ export function createWindow(props?: WindowProps): BrowserWindow {
     try {
       const u = new URL(details.url);
 
-      // Don't open URLs with protocols other than http / https externally since they may open other apps.
-      if (u.protocol !== 'https:' && u.protocol !== 'http:') {
+      // Don't open URLs with protocols other than those we explicitly allow otherwise to prevent users
+      // from opening external apps and running untrusted code that could compromise their machines.
+      if (!EXTERNAL_PROTOCOLS_ALLOW_LIST.includes(u.protocol)) {
         return {
           action: 'deny',
         };
@@ -208,14 +209,13 @@ export function createWindow(props?: WindowProps): BrowserWindow {
 
     // Prevent navigation away from Replit or supported pages
     if (!isReplit || !isSupportedPage(u.pathname)) {
-      event.preventDefault();
-
       // Don't open URLs with protocols other than those we explicitly allow otherwise to prevent users
       // from opening external apps and running untrusted code that could compromise their machines.
       if (!EXTERNAL_PROTOCOLS_ALLOW_LIST.includes(u.protocol)) {
         return;
       }
 
+      event.preventDefault();
       shell.openExternal(navigationUrl);
     }
   });


### PR DESCRIPTION
# Why

Follow on to https://github.com/replit/desktop/pull/151, I missed a spot here when I updated our allowlisted protocols to include `replit://` and `vscode://`. We need to update the window open handler logic to match that of the `will-navigate` event handler to account for URLs opened via `target="_blank"` and programmatically via `window.open`. This ensures the behavior will be consistent to what we see in the `will-navigate` handler which fires in all other cases.

# What changed

Update window open handler to accept new allowlisted protocols to match what we do in the will nav handler so that `target=_blank` and `window.open` work as expected.

# Test plan 

- Open desktop app in dev
- Open browser console
- Enter `window.open("replit://new")`
- Previously (on main) this be a no-op and not do anything
- Now, this will open a new Replit window to the new repl flow as expected
