### PR TITLE
Log when openExternal is called in window event handlers

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -191,6 +191,7 @@ export function createWindow(props?: WindowProps): BrowserWindow {
       };
     }
 
+    log.info('Opening external URL in window open handler: ', details);
     shell.openExternal(details.url);
 
     return {
@@ -202,8 +203,8 @@ export function createWindow(props?: WindowProps): BrowserWindow {
     setLastOpenRepl(navigationUrl, lastOpenRepl);
   });
 
-  window.webContents.on('will-navigate', (event, navigationUrl) => {
-    const u = new URL(navigationUrl);
+  window.webContents.on('will-navigate', (event) => {
+    const u = new URL(event.url);
 
     const isReplit = u.origin === baseUrl;
 
@@ -216,7 +217,8 @@ export function createWindow(props?: WindowProps): BrowserWindow {
       }
 
       event.preventDefault();
-      shell.openExternal(navigationUrl);
+      log.info('Opening external URL in will-navigate event handler: ', event);
+      shell.openExternal(event.url);
     }
   });
 


### PR DESCRIPTION
# Why

We've been seeing a bug in the app where a certain repl or tab will be opened in your browser while the app is running in the background. I'm not sure why this happens tbh and can't find any logs from those that have reported this issue in Datadog (which is where we log when we open external URLs on the web side) so we should add some logging on the native side too to help us investigate. See attached Linear issue and [Slack thread](https://replit.slack.com/archives/C030RJ2PRC7/p1710882054643799) for more detail.

references WS-2021

# What changed

Log when openExternal is called in window event handlers. Also replacing a use of the deprecated `navigationUrl` param while I'm at it

# Test plan 

- Should see relevant logs with event details next time someone reports this
