### PR TITLE
Update app to support Teams Repl URLs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,7 +20,13 @@ export const isLoadingLocalReplit = baseUrl.includes('localhost');
 export const isLoadingStagingReplit = baseUrl.includes('staging');
 export const isLoadingProdReplit = baseUrl === defaultBaseUrl;
 
-export const workspaceUrlRegex = /^\/@\S+\/\S+/;
+// Generated using path-to-regexp, the same package express uses to parse routes.
+// See: https://github.com/pillarjs/path-to-regexp
+// Matches /@:username/:slug
+export const personalReplUrlRegex = /^\/@([^/#?]+?)(?:\/([^/#?]+?))[/#?]?$/i;
+// Matches /t/:orgSlug/:orgId/repls/:replSlug
+export const teamReplUrlRegex =
+  /^\/t(?:\/([^/#?]+?))(?:\/([^/#?]+?))\/repls(?:\/([^/#?]+?))[/#?]?$/i;
 
 export const homePage = '/desktopApp/home';
 export const authPage = '/desktopApp/auth';

--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -11,7 +11,8 @@ import {
   appName as title,
   baseUrl,
   preloadScript as preload,
-  workspaceUrlRegex,
+  teamReplUrlRegex,
+  personalReplUrlRegex,
   homePage,
   isProduction,
 } from './constants';
@@ -54,7 +55,10 @@ function setLastOpenRepl(url: string, lastOpenRepl: string | null) {
     return;
   }
 
-  if (!workspaceUrlRegex.test(u.pathname)) {
+  if (
+    !personalReplUrlRegex.test(u.pathname) &&
+    !teamReplUrlRegex.test(u.pathname)
+  ) {
     return;
   }
 

--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -3,7 +3,8 @@ import { isWindows, isLinux } from './platform';
 import {
   baseUrl,
   protocol,
-  workspaceUrlRegex,
+  personalReplUrlRegex,
+  teamReplUrlRegex,
   semverRegex,
   authPage,
   homePage,
@@ -127,8 +128,8 @@ function handleNew(language: string) {
 }
 
 function handleRepl(url: string) {
-  if (!workspaceUrlRegex.test(url)) {
-    log.error('Expected URL of the format /@username/slug');
+  if (!personalReplUrlRegex.test(url) && !teamReplUrlRegex.test(url)) {
+    log.error('Expected valid workspace URL');
 
     return;
   }

--- a/src/isSupportedPage.ts
+++ b/src/isSupportedPage.ts
@@ -1,11 +1,16 @@
-import { desktopAppPrefix, workspaceUrlRegex } from './constants';
+import {
+  desktopAppPrefix,
+  personalReplUrlRegex,
+  teamReplUrlRegex,
+} from './constants';
 
 const supportedNonDesktopAppPages = ['logout'];
 
 export default function isSupportedPage(page: string): boolean {
   return (
     page.startsWith(desktopAppPrefix) ||
-    workspaceUrlRegex.test(page) ||
+    personalReplUrlRegex.test(page) ||
+    teamReplUrlRegex.test(page) ||
     supportedNonDesktopAppPages.includes(page)
   );
 }


### PR DESCRIPTION
# Why

We want to support teams Repls in the desktop app

Analogous to the web change here: https://github.com/replit/repl-it-web/pull/43871

# What changed

Add support for the Teams Repl URL format, similar to the above PR in web. Also use a more robust version of the personal Repl Regexp generated using `path-to-regexp`

# Test plan 

Should be able to open both teams and personal Repls now in the app via both client-side and server side transitions, incl deeplinks.
