### PR TITLE
Update x64/Arm Mac runners in GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macOS-13-xlarge, macOS-latest, ubuntu-latest, windows-latest ]
+        os: [ macOS-latest, macOS-12, ubuntu-latest, windows-latest ]
         arch: [ x64, arm64 ]
         # Publishing artifacts for multiple Windows architectures has
         # a bug which can cause the wrong architecture to be downloaded
@@ -68,9 +68,9 @@ jobs:
           arch: arm64
         # Only build arm64 builds on M1 and x86 builds on Intel Mac
         - os: macOS-latest 
-          arch: arm64
-        - os: macOS-13-xlarge 
           arch: x64
+        - os: macOS-12
+          arch: arm64
 
     steps:
       - uses: actions/checkout@v3
@@ -96,7 +96,7 @@ jobs:
           fileName: 'windows-certificate.pfx'
           encodedString: ${{ secrets.WINDOWS_CODESIGN_CERTIFICATE }}
       - name: Generate MacOS code signing certificate
-        if: matrix.os == 'macOS-latest' || matrix.os == 'macOS-13-xlarge'
+        if: matrix.os == 'macOS-latest' || matrix.os == 'macOS-12'
         run: ./scripts/add-macos-cert.sh
         env:
           MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macOS-13-xlarge, macOS-latest, ubuntu-latest, windows-latest ]
+        os: [ macOS-latest, macOS-12, ubuntu-latest, windows-latest ]
         arch: [ x64, arm64 ]
         # Publishing artifacts for multiple Windows architectures has
         # a bug which can cause the wrong architecture to be downloaded
@@ -20,9 +20,9 @@ jobs:
           arch: arm64
         # Only build arm64 builds on M1 and x86 builds on Intel Mac
         - os: macOS-latest 
-          arch: arm64
-        - os: macOS-13-xlarge 
           arch: x64
+        - os: macOS-12 
+          arch: arm64 
 
     steps:
       - uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
           fileName: 'windows-certificate.pfx'
           encodedString: ${{ secrets.WINDOWS_CODESIGN_CERTIFICATE }}
       - name: Generate MacOS code signing certificate
-        if: matrix.os == 'macOS-latest' || matrix.os == 'macOS-13-xlarge'
+        if: matrix.os == 'macOS-latest' || matrix.os == 'macOS-12'
         run: ./scripts/add-macos-cert.sh
         env:
           MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}


### PR DESCRIPTION
# Why

I found out today that the `macos-latest` GH actions runner got switched out from under our feet in the past month since we last published and now the machine that runs those actions is an Apple Silicon (ARM) chip instead of an older Intel-based Mac. See relevant changelog: https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/

The implication of this is that now both our "x64" and "arm64" jobs in GH actions are, in fact, producing arm64 based artifacts.

# What changed

Update x64/Arm Mac runners in GH Actions. Now, the macos-latest runner corresponds to Apple Silicon (ARM) machines, meaning we no longer need the xlarge runner, and the `macOS-12` runner corresponds to Intel chip builds.

# Test plan 

Should produce 2 separate DMGs, one for each architecture, on next run 🤞 In the meantime, the "runner details" in the GH actions logs in CI should indicate that they are running on the appropriate architecture.
