### PR TITLE
Only open windows externally if window is focused

### DIFF
--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -195,8 +195,11 @@ export function createWindow(props?: WindowProps): BrowserWindow {
       };
     }
 
-    log.info('Opening external URL in window open handler: ', details);
-    shell.openExternal(details.url);
+    // Only open externally if the window is actually focused to prevent windows from opening in the background.
+    if (window.isFocused()) {
+      log.info('Opening external URL in window open handler: ', details);
+      shell.openExternal(details.url);
+    }
 
     return {
       action: 'deny',
@@ -221,8 +224,15 @@ export function createWindow(props?: WindowProps): BrowserWindow {
       }
 
       event.preventDefault();
-      log.info('Opening external URL in will-navigate event handler: ', event);
-      shell.openExternal(event.url);
+
+      // Only open externally if the window is actually focused to prevent windows from opening in the background.
+      if (window.isFocused()) {
+        log.info(
+          'Opening external URL in will-navigate event handler: ',
+          event,
+        );
+        shell.openExternal(event.url);
+      }
     }
   });
 


### PR DESCRIPTION
# Why

We've gotten some reports of the desktop app randomly opening pages when unfocused and in the background. I have a feeling this is due to some of our "openExternal" logic around redirecting non-Replit pages (or those not supported in the desktop app) to the user's browser instead. I'm not sure _why_ this would be occurring in the background since this should usually only happen by the user clicking links or something triggering `window.open` but evidently it is. See [Slack thread](https://replit.slack.com/archives/C0509G0FJNL/p1710457178647839).

# What changed

Only open external links in the user's browser if the window is actually focused. This will stop tabs from opening when the app is in the background.

# Test plan 

- Open external links by clicking a link or calling `window.open` in the console when the app is focused -> should still open external links in the browser
- Should stop getting reports of this happening when the app is unfocused though.
