### PR TITLE
Remove open from clipboard menu item

### DIFF
--- a/src/createMenu.ts
+++ b/src/createMenu.ts
@@ -1,16 +1,12 @@
 import {
   app,
-  clipboard,
-  dialog,
   Menu,
   MenuItem,
   MenuItemConstructorOptions,
 } from 'electron';
-import { baseUrl, isProduction } from './constants';
+import { isProduction } from './constants';
 import { createWindow } from './createWindow';
 import { isMac } from './platform';
-
-const replUrlRegExp = new RegExp(`${baseUrl}/@[^/]+/.+`);
 
 const newWindowMenuItem = {
   label: 'New Window',
@@ -18,28 +14,10 @@ const newWindowMenuItem = {
   click: () => createWindow(),
 };
 
-const openReplFromClipboardMenuItem = {
-  label: 'Open Repl URL from Clipboard',
-  click: () => {
-    const clipboardText = clipboard.readText();
-    const isReplUrl = replUrlRegExp.test(clipboardText);
-
-    if (isReplUrl) {
-      createWindow({ url: clipboardText });
-    } else {
-      dialog.showMessageBox({
-        type: 'warning' as const,
-        message: 'The URL in Clipboard is not a Repl URL',
-      });
-    }
-  },
-};
-
 export function createDockMenu(): Menu {
   const menu = new Menu();
 
   menu.append(new MenuItem(newWindowMenuItem));
-  menu.append(new MenuItem(openReplFromClipboardMenuItem));
 
   return menu;
 }
@@ -72,7 +50,6 @@ export function createApplicationMenu(): Menu {
     label: 'File',
     submenu: [
       newWindowMenuItem,
-      openReplFromClipboardMenuItem,
       { type: 'separator' },
       isMac() ? { role: 'close' } : { role: 'quit' },
     ],


### PR DESCRIPTION
# Why

It's currently broken for team repls since only the old Repl URL format is supported (and not the most [correct one](https://github.com/replit/desktop/blob/02a4373e9063283459d4ea1e6ce8cee2b93e475b/src/constants.ts#L23-L26) at that).

We can trivially add support for it but I'm thinking it's better to just remove this feature since it's not clear anyone is deriving value from this and it's pretty un-intuitive to use. We should instead follow up with an easier way to open a Repl with a given URL baked into the UI rather than a hidden / confusing menu item.

Closes WS-3389

# What changed

Remove open from clipboard menu item

# Test plan 

- Open desktop app
- Click "File" at the top menu bar in macOS
- Should not see "Open from clipboard"
