### PR TITLE
Upgrade Electron to 30.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@typescript-eslint/parser": "^4.33.0",
     "cpy": "^9.0.1",
     "cross-env": "^7.0.3",
-    "electron": "^28.1.0",
+    "electron": "^30.0.3",
     "electron-winstaller": "^5.1.0",
     "esbuild": "^0.18.6",
     "eslint": "^8.47.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,8 +56,8 @@ devDependencies:
     specifier: ^7.0.3
     version: 7.0.3
   electron:
-    specifier: ^28.1.0
-    version: 28.1.0
+    specifier: ^30.0.3
+    version: 30.0.3
   electron-winstaller:
     specifier: ^5.1.0
     version: 5.2.1
@@ -1145,12 +1145,6 @@ packages:
     dev: true
     optional: true
 
-  /@types/node@18.18.14:
-    resolution: {integrity: sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==}
-    dependencies:
-      undici-types: 5.26.5
-    dev: true
-
   /@types/node@20.10.5:
     resolution: {integrity: sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==}
     dependencies:
@@ -2235,14 +2229,14 @@ packages:
       - supports-color
     dev: true
 
-  /electron@28.1.0:
-    resolution: {integrity: sha512-82Y7o4PSWPn1o/aVwYPsgmBw6Gyf2lVHpaBu3Ef8LrLWXxytg7ZRZr/RtDqEMOzQp3+mcuy3huH84MyjdmP50Q==}
+  /electron@30.0.3:
+    resolution: {integrity: sha512-h+suwx6e0fnv/9wi0/cmCMtG+4LrPzJZa+3DEEpxcPcP+pcWnBI70t8QspxgMNIh2wzXLMD9XVqrLkEbiBAInw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 18.18.14
+      '@types/node': 20.10.5
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
# Why

Electron is now on major version 30. Let's upgrade to the [latest version](https://github.com/electron/electron/releases/tag/v30.0.3) to make sure we get all the new features and bug fixes.

# What changed

Upgrade Electron to 30.0.3

# Test plan 

Desktop app opens and works as expected
