### PR TITLE
Remove unused / revoked Sentry auth token

### DIFF
--- a/sentry.properties
+++ b/sentry.properties
@@ -1,4 +1,3 @@
 defaults.url=https://sentry.io/
 defaults.org=replit-kq
 defaults.project=desktop
-auth.token=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


### PR DESCRIPTION
# Why

Looks like this was committed as part of https://github.com/replit/desktop/pull/130 when I set up Sentry for the app. AFAIK this was recommended to commit after it was outputted by the Sentry Wizard but I'm having trouble finding the docs around this now. In any case, this token has not been used according to our project dashboard and long been revoked so we should remove it here to avoid confusion and not make it look like we commit our secrets haha

# What changed

Remove unused / revoked Sentry auth token

# Test plan 

No effect. Sentry should still continue working as expected in the desktop project.
