### PR TITLE
Update desktop app to support new org urls (desktop app update)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,7 +27,7 @@ export const personalReplUrlRegex = /^\/@([^/#?]+?)(?:\/([^/#?]+?))[/#?]?$/i;
 // Matches /t/:orgSlug/:orgId/repls/:replSlug
 export const legacyTeamReplUrlRegex =
   /^\/t(?:\/([^/#?]+?))(?:\/([^/#?]+?))\/repls(?:\/([^/#?]+?))[/#?]?$/i;
-// Matches /t/:orgSlug/:orgId/repls/:replSlug
+// Matches /t/:orgSlug/repls/:replSlug
 export const teamReplUrlRegex =
   /^\/t(?:\/([^/#?]+?))\/repls(?:\/([^/#?]+?))[/#?]?$/i;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,8 +25,11 @@ export const isLoadingProdReplit = baseUrl === defaultBaseUrl;
 // Matches /@:username/:slug
 export const personalReplUrlRegex = /^\/@([^/#?]+?)(?:\/([^/#?]+?))[/#?]?$/i;
 // Matches /t/:orgSlug/:orgId/repls/:replSlug
-export const teamReplUrlRegex =
+export const legacyTeamReplUrlRegex =
   /^\/t(?:\/([^/#?]+?))(?:\/([^/#?]+?))\/repls(?:\/([^/#?]+?))[/#?]?$/i;
+// Matches /t/:orgSlug/:orgId/repls/:replSlug
+export const teamReplUrlRegex =
+  /^\/t(?:\/([^/#?]+?))\/repls(?:\/([^/#?]+?))[/#?]?$/i;
 
 export const homePage = '/desktopApp/home';
 export const authPage = '/desktopApp/auth';

--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -15,6 +15,7 @@ import {
   personalReplUrlRegex,
   homePage,
   isProduction,
+  legacyTeamReplUrlRegex,
 } from './constants';
 import log from 'electron-log/main';
 import { events } from './events';
@@ -57,7 +58,8 @@ function setLastOpenRepl(url: string, lastOpenRepl: string | null) {
 
   if (
     !personalReplUrlRegex.test(u.pathname) &&
-    !teamReplUrlRegex.test(u.pathname)
+    !teamReplUrlRegex.test(u.pathname) &&
+    !legacyTeamReplUrlRegex.test(u.pathname)
   ) {
     return;
   }

--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -8,6 +8,7 @@ import {
   semverRegex,
   authPage,
   homePage,
+  legacyTeamReplUrlRegex,
 } from './constants';
 import path from 'path';
 import { createWindow } from './createWindow';
@@ -128,7 +129,11 @@ function handleNew(language: string) {
 }
 
 function handleRepl(url: string) {
-  if (!personalReplUrlRegex.test(url) && !teamReplUrlRegex.test(url)) {
+  if (
+    !personalReplUrlRegex.test(url) && 
+    !teamReplUrlRegex.test(url) && 
+    !legacyTeamReplUrlRegex.test(url)
+  ) {
     log.error('Expected valid workspace URL');
 
     return;

--- a/src/isSupportedPage.ts
+++ b/src/isSupportedPage.ts
@@ -1,5 +1,6 @@
 import {
   desktopAppPrefix,
+  legacyTeamReplUrlRegex,
   personalReplUrlRegex,
   teamReplUrlRegex,
 } from './constants';
@@ -11,6 +12,7 @@ export default function isSupportedPage(page: string): boolean {
     page.startsWith(desktopAppPrefix) ||
     personalReplUrlRegex.test(page) ||
     teamReplUrlRegex.test(page) ||
+    legacyTeamReplUrlRegex.test(page) ||
     supportedNonDesktopAppPages.includes(page)
   );
 }


### PR DESCRIPTION
# Why

<!-- Describe what prompted you to make this change, link relevant resources: Asana tasks, Canny report, Slack discussions, etc -->

Update the desktop app to support the new org URLs which are in the form /t/orgSlug/orgId/repls/replSlug.

# What changed

<!-- Describe what changed to a level of detail that someone with no context with your PR could be able to review it (including screenshots if relevant) -->

- add `teamReplUrlRegex ` for /t/:orgSlug/repls/:replSlug
- add `legacyTeamReplUrlRegex` for /t/:orgSlug/:orgId/repls/:replSlug

# Test plan 

- create org repl
- `pnpm start:local`
- load the desktop homepage
- log in
- load the org repl
- should work

https://github.com/user-attachments/assets/2945f69d-149d-4159-a1ff-dbd3a8624e0a




<!-- Describe what you did to test this change to a level of detail that allows your reviewer to test it -->
