### PR TITLE
make auth flow possible to complete in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ You can then launch a packaged version of the app (needed to test certain featur
 
 To test your changes on other platforms, we recommend using a Virtual Machine host like [UTM](https://mac.getutm.app).
 
+When going through the authentication flow in development (through unpackaged app) on macOS and Linux, after clicking "Login" on the welcome page, a new empty Electron window will open. This is expected, as [deeplinks are not support in unpackaged apps](https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app#:~:text=On%20macOS%20and%20Linux%2C%20this%20feature%20will%20only%20work%20when%20your%20app%20is%20packaged.%20It%20will%20not%20work%20when%20you%27re%20launching%20it%20in%20development%20from%20the%20command%2Dline). To finish the flow, copy the URL from the browser into the clipboard (it should look like `http://localhost:3000/desktopApp/authSuccess?authToken=...`), and from the app menubar choose "File -> Complete Auth From Clipboard". This menu item is only available in dev.
+
 ## API Versioning
 
 The Electron app communicates with the web frontend through the `replitDesktop` global object defined in `src/preload.ts`. As we develop both applications, this API has to be able to adapt, but at the same time can't break existing clients. The main failure mode we're trying to avoid is someone opening an older version of the Electron app and loading a newer version of the web client which requires a new API that's not supported by the old Electron client.
@@ -100,3 +102,4 @@ Note that to recreate the `pfx` file (which is what's ultimately needed to sign 
 ### CI
 
 We sign the app in CI as part of the build and release process when publishing a new release. Make sure that the above env vars (`APPLE_*` and `WINDOWS_*`) remain valid credentials and are kept up to date in the repository secrets settings used by GitHub actions otherwise the app will not get correctly signed on subsequent releases.
+

--- a/src/deeplink.ts
+++ b/src/deeplink.ts
@@ -130,8 +130,8 @@ function handleNew(language: string) {
 
 function handleRepl(url: string) {
   if (
-    !personalReplUrlRegex.test(url) && 
-    !teamReplUrlRegex.test(url) && 
+    !personalReplUrlRegex.test(url) &&
+    !teamReplUrlRegex.test(url) &&
     !legacyTeamReplUrlRegex.test(url)
   ) {
     log.error('Expected valid workspace URL');
@@ -152,7 +152,7 @@ function handleRepl(url: string) {
   });
 }
 
-function handleAuthComplete(authToken: string) {
+export function handleAuthComplete(authToken: string) {
   const windows = BrowserWindow.getAllWindows();
   const authUrl = `${baseUrl}${authPage}`;
 


### PR DESCRIPTION
# Why

Our auth flow relies on deeplinks (mainly, opening `replit://authComplete?authToken=...`). [Deeplinks are not supported in dev](https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app#:~:text=On%20macOS%20and%20Linux%2C%20this%20feature%20will%20only%20work%20when%20your%20app%20is%20packaged.%20It%20will%20not%20work%20when%20you%27re%20launching%20it%20in%20development%20from%20the%20command%2Dline) so we currently can't log in using an unpackaged app. Honestly I have no idea if/how we used this in the past.

This PR adds a "Complete Auth From Clipboard" menu item (only in dev -- unpackaged app) which allows us to complete the auth flow in dev, by copying the callback URL from the browser, and clicking that menu item.

# What changed

As described above.

# Test plan 

- run the web app on localhost
- `pnpm start:local` in `desktop`
- click login - see the flow complete but new empty electron opens (this is expected) - close that window
- go to browser and copy the URL (should look like: `http://localhost:3000/desktopApp/authSuccess?authToken=...`)
- click the menu item - get logged in!
