### PR TITLE
make windows feel more native

### DIFF
--- a/src/createMenu.ts
+++ b/src/createMenu.ts
@@ -13,7 +13,7 @@ import { isMac } from './platform';
 
 const newWindowMenuItem = {
   label: 'New Window',
-  accelerator: 'CommandOrControl+Shift+N',
+  accelerator: 'CommandOrControl+N',
   click: () => createWindow(),
 };
 

--- a/src/createWindow.ts
+++ b/src/createWindow.ts
@@ -71,6 +71,15 @@ function setLastOpenRepl(url: string, lastOpenRepl: string | null) {
   store.setLastOpenRepl(u.pathname);
 }
 
+function offsetRectangle(rect: Rectangle, offset = { x: 20, y: 20 }) {
+  return {
+    x: rect.x + offset.x,
+    y: rect.y + offset.y,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
 function isInBounds(rect: Rectangle) {
   return screen.getAllDisplays().some(({ bounds }) => {
     const { x, y, width, height } = bounds;
@@ -247,7 +256,8 @@ export function createWindow(props?: WindowProps): BrowserWindow {
     store.clearWindowBounds();
   }
 
-  window.setBounds(store.getWindowBounds());
+  // We offset new windows a bit so they are visible if spawned on top of existing ones
+  window.setBounds(offsetRectangle(store.getWindowBounds()));
 
   window.on('close', () => {
     store.setWindowBounds(window.getBounds());

--- a/src/store.ts
+++ b/src/store.ts
@@ -82,8 +82,33 @@ function createStore() {
       // This fixes the bug where opening a Repl from a Splash Screen opens it on some other display.
       const mousePosition = screen.getCursorScreenPoint();
       const mouseScreen = screen.getDisplayNearestPoint(mousePosition);
+      const workArea = mouseScreen.workArea;
 
-      return store.get(Key.WINDOW_BOUNDS, mouseScreen.workArea) as Rectangle;
+      const DEFAULT_WIDTH = 1200;
+      const DEFAULT_HEIGHT = 900;
+      const PADDING = 40;
+
+      let defaultBounds: Rectangle;
+      if (
+        DEFAULT_WIDTH <= workArea.width &&
+        DEFAULT_HEIGHT <= workArea.height
+      ) {
+        // If the window fits, center it in the work area
+        const x = workArea.x + Math.floor((workArea.width - DEFAULT_WIDTH) / 2);
+        const y =
+          workArea.y + Math.floor((workArea.height - DEFAULT_HEIGHT) / 2);
+        defaultBounds = { x, y, width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT };
+      } else {
+        // If the default size is larger than the work area, shrink it
+        defaultBounds = {
+          x: workArea.x + PADDING,
+          y: workArea.y + PADDING,
+          width: workArea.width - PADDING * 2,
+          height: workArea.height - PADDING * 2,
+        };
+      }
+
+      return store.get(Key.WINDOW_BOUNDS, defaultBounds) as Rectangle;
     },
     getUser(): User | null {
       return store.get(Key.USER_INFO, null) as User | null;


### PR DESCRIPTION
# Why

- covering the screen fully without gaps feels off
- cmd-shift-n instead of cmd-n for new window is weird too
- new windows spawning exactly over existing ones looks weird as well

# What changed

- switched cmd-shift-n to cmd-n
- made it so new window without any past stored config has some default size, and if too big to fit the display, it shrinks
- finally new windows spawn with some offset

# Test plan 

As described above.
