### PR TITLE
use hostname instead of host for fallback dev config store

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -41,9 +41,9 @@ function getStoreName() {
   }
 
   // Other URLs could be repl.co URLs from hosted RoR instances
-  const { host } = new URL(baseUrl);
+  const { hostname } = new URL(baseUrl);
 
-  return `config-dev-${host}`;
+  return `config-dev-${hostname}`;
 }
 
 function createStore() {


### PR DESCRIPTION
# Why

`host` can have a `:port`, `hostname` is just hostname; some OS-es don't allow making filenames with `:`.

# What changed

As described above.

# Test plan 

`REPLIT_URL="http://machine:3000" electron-forge start` doesn't crash the app anymore.
